### PR TITLE
feat(download): resume verified payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ manifest-bound install receipt for fast offline launches, and only promotes
 fully written rootfs and writable-disk staging files into place. When publishing
 a new image release, update `defaultReleaseURL`, `defaultSumsSHA256`, and the
 matching fixture in `app/testdata`, plus `currentVersion` in `app/update.go`.
+Interrupted payload transfers resume from their `.part` files when the server
+supports byte ranges, then the complete file is SHA256-verified before use.
 Custom release URLs must be paired with the
 trusted manifest digest via `-sums-sha256`.
 

--- a/app/download.go
+++ b/app/download.go
@@ -1,0 +1,366 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	downloadPhaseTransfer = "download"
+	downloadPhaseVerify   = "verify"
+)
+
+type downloadProgress func(phase string, done, total int64)
+
+type downloadOptions struct {
+	maxAttempts int
+	idleTimeout time.Duration
+	retryDelay  func(attempt int) time.Duration
+}
+
+func defaultDownloadOptions() downloadOptions {
+	return downloadOptions{
+		maxAttempts: 4,
+		idleTimeout: 90 * time.Second,
+		retryDelay: func(attempt int) time.Duration {
+			return time.Duration(1<<(attempt-1)) * 500 * time.Millisecond
+		},
+	}
+}
+
+// newDownloadClient bounds connection and response-header stalls without
+// imposing a total deadline on multi-gigabyte payload transfers.
+func newDownloadClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = 30 * time.Second
+	transport.TLSHandshakeTimeout = 15 * time.Second
+	return &http.Client{Transport: transport}
+}
+
+// downloadVerified resumes a sibling .part file when the server honors byte
+// ranges, then authenticates the complete file before publishing it.
+func downloadVerified(client *http.Client, url, dest, wantSum string, progress downloadProgress) error {
+	return downloadVerifiedWithOptions(client, url, dest, wantSum, progress, defaultDownloadOptions())
+}
+
+func downloadVerifiedWithOptions(client *http.Client, url, dest, wantSum string, progress downloadProgress, opts downloadOptions) error {
+	wantSum = normalizedSHA256(wantSum)
+	if !validSHA256(wantSum) {
+		return fmt.Errorf("release manifest has no valid SHA256 for %s", filepath.Base(dest))
+	}
+	if client == nil {
+		return fmt.Errorf("download client is nil")
+	}
+	if opts.maxAttempts < 1 {
+		opts.maxAttempts = 1
+	}
+	var lastErr error
+	cleanRestartUsed := false
+	for attempt := 1; attempt <= opts.maxAttempts; {
+		retry, cleanRestart, err := downloadAttempt(client, url, dest, wantSum, progress, opts.idleTimeout)
+		if err == nil {
+			return nil
+		}
+		if cleanRestart {
+			if cleanRestartUsed {
+				return err
+			}
+			cleanRestartUsed = true
+			lastErr = err
+			continue
+		}
+		if !retry {
+			return err
+		}
+		lastErr = err
+		if attempt < opts.maxAttempts && opts.retryDelay != nil {
+			if err := sleepDuringSetup(opts.retryDelay(attempt)); err != nil {
+				return err
+			}
+		}
+		attempt++
+	}
+	return fmt.Errorf("download failed after %d attempts: %w", opts.maxAttempts, lastErr)
+}
+
+func downloadAttempt(client *http.Client, url, dest, wantSum string, progress downloadProgress, idleTimeout time.Duration) (retry, cleanRestart bool, resultErr error) {
+	if err := checkSetupCancelled(); err != nil {
+		return false, false, err
+	}
+	tmp := dest + ".part"
+	offset, err := partialFileSize(tmp)
+	if err != nil {
+		return false, false, err
+	}
+	req, err := http.NewRequestWithContext(setupContext(), http.MethodGet, url, nil)
+	if err != nil {
+		return false, false, err
+	}
+	req.Header.Set("Accept-Encoding", "identity")
+	if offset > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", offset))
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		if cancelErr := checkSetupCancelled(); cancelErr != nil {
+			return false, false, cancelErr
+		}
+		return true, false, err
+	}
+	defer resp.Body.Close()
+
+	appendPart := false
+	segmentLength := resp.ContentLength
+	total := resp.ContentLength
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// The server ignored Range. Restart safely using this full response.
+		offset = 0
+	case http.StatusPartialContent:
+		start, end, completeLength, ok := parseContentRange(resp.Header.Get("Content-Range"))
+		if !ok || start != offset || end < start || completeLength <= end {
+			if err := resetPartialFile(tmp); err != nil {
+				return false, false, err
+			}
+			return true, false, fmt.Errorf("server returned an invalid Content-Range for offset %d", offset)
+		}
+		segmentLength = end - start + 1
+		if resp.ContentLength >= 0 && resp.ContentLength != segmentLength {
+			if err := resetPartialFile(tmp); err != nil {
+				return false, false, err
+			}
+			return true, false, fmt.Errorf("server returned a mismatched ranged content length")
+		}
+		total = completeLength
+		appendPart = offset > 0
+	case http.StatusRequestedRangeNotSatisfiable:
+		if offset == 0 {
+			return false, false, fmt.Errorf("HTTP %d", resp.StatusCode)
+		}
+		ok, err := verifyAndCommitPart(tmp, dest, wantSum, progress)
+		if err != nil {
+			return false, false, err
+		}
+		if ok {
+			return false, false, nil
+		}
+		if err := resetPartialFile(tmp); err != nil {
+			return false, false, err
+		}
+		return false, true, fmt.Errorf("server rejected the cached partial download")
+	default:
+		retry = resp.StatusCode == http.StatusRequestTimeout ||
+			resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500
+		return retry, false, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	flags := os.O_CREATE | os.O_WRONLY
+	if appendPart {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+	}
+	f, err := os.OpenFile(tmp, flags, 0o644)
+	if err != nil {
+		return false, false, err
+	}
+	if appendPart {
+		info, err := f.Stat()
+		if err != nil {
+			f.Close()
+			return false, false, err
+		}
+		if info.Size() != offset {
+			f.Close()
+			return true, false, fmt.Errorf("partial download changed while resuming")
+		}
+	}
+	if progress != nil {
+		progress(downloadPhaseTransfer, offset, total)
+	}
+	written, retry, copyErr := copyDownloadBody(resp.Body, f, offset, total, progress, idleTimeout)
+	syncErr := f.Sync()
+	closeErr := f.Close()
+	if syncErr != nil {
+		return false, false, syncErr
+	}
+	if closeErr != nil {
+		return false, false, closeErr
+	}
+	if copyErr != nil {
+		return retry, false, copyErr
+	}
+	if segmentLength >= 0 && written != segmentLength {
+		return true, false, fmt.Errorf("download ended after %d of %d response bytes", written, segmentLength)
+	}
+	info, err := os.Stat(tmp)
+	if err != nil {
+		return false, false, err
+	}
+	if total >= 0 && info.Size() != total {
+		if info.Size() > total {
+			if err := resetPartialFile(tmp); err != nil {
+				return false, false, err
+			}
+		}
+		return true, false, fmt.Errorf("partial download is %d bytes; expected %d", info.Size(), total)
+	}
+	ok, err := verifyAndCommitPart(tmp, dest, wantSum, progress)
+	if err != nil {
+		return false, false, err
+	}
+	if !ok {
+		if appendPart {
+			if err := resetPartialFile(tmp); err != nil {
+				return false, false, err
+			}
+			return false, true, fmt.Errorf("resumed download did not match the current payload")
+		}
+		os.Remove(tmp)
+		return false, false, fmt.Errorf("checksum mismatch - the download is corrupt, try again")
+	}
+	return false, false, nil
+}
+
+func partialFileSize(path string) (int64, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	if !info.Mode().IsRegular() {
+		return 0, fmt.Errorf("partial download is not a regular file: %s", path)
+	}
+	return info.Size(), nil
+}
+
+func resetPartialFile(path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func verifyAndCommitPart(tmp, dest, wantSum string, progress downloadProgress) (bool, error) {
+	ok, err := verifyFileSHA256(tmp, wantSum, func(done, total int64) {
+		if progress != nil {
+			progress(downloadPhaseVerify, done, total)
+		}
+	})
+	if err != nil || !ok {
+		return ok, err
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func copyDownloadBody(body io.ReadCloser, dst io.Writer, offset, total int64, progress downloadProgress, idleTimeout time.Duration) (int64, bool, error) {
+	var timedOut atomic.Bool
+	var activity chan struct{}
+	var done chan struct{}
+	ctx := setupContext()
+	if idleTimeout > 0 {
+		activity = make(chan struct{}, 1)
+		done = make(chan struct{})
+		go func() {
+			timer := time.NewTimer(idleTimeout)
+			defer timer.Stop()
+			for {
+				select {
+				case <-activity:
+					if !timer.Stop() {
+						select {
+						case <-timer.C:
+						default:
+						}
+					}
+					timer.Reset(idleTimeout)
+				case <-timer.C:
+					timedOut.Store(true)
+					body.Close()
+					return
+				case <-ctx.Done():
+					body.Close()
+					return
+				case <-done:
+					return
+				}
+			}
+		}()
+		defer close(done)
+	}
+	buf := make([]byte, 1<<20)
+	var written int64
+	for {
+		if err := checkSetupCancelled(); err != nil {
+			return written, false, err
+		}
+		n, readErr := body.Read(buf)
+		if n > 0 {
+			if _, err := dst.Write(buf[:n]); err != nil {
+				return written, false, err
+			}
+			written += int64(n)
+			if activity != nil {
+				select {
+				case activity <- struct{}{}:
+				default:
+				}
+			}
+			if progress != nil {
+				progress(downloadPhaseTransfer, offset+written, total)
+			}
+		}
+		if readErr == io.EOF {
+			return written, false, nil
+		}
+		if readErr != nil {
+			if err := checkSetupCancelled(); err != nil {
+				return written, false, err
+			}
+			if timedOut.Load() {
+				return written, true, fmt.Errorf("download stalled for %s", idleTimeout)
+			}
+			return written, true, readErr
+		}
+	}
+}
+
+func parseContentRange(value string) (start, end, total int64, ok bool) {
+	if !strings.HasPrefix(value, "bytes ") {
+		return 0, 0, 0, false
+	}
+	rangeAndTotal := strings.Split(strings.TrimPrefix(value, "bytes "), "/")
+	if len(rangeAndTotal) != 2 || rangeAndTotal[1] == "*" {
+		return 0, 0, 0, false
+	}
+	bounds := strings.Split(rangeAndTotal[0], "-")
+	if len(bounds) != 2 {
+		return 0, 0, 0, false
+	}
+	start, err := strconv.ParseInt(bounds[0], 10, 64)
+	if err != nil || start < 0 {
+		return 0, 0, 0, false
+	}
+	end, err = strconv.ParseInt(bounds[1], 10, 64)
+	if err != nil || end < start {
+		return 0, 0, 0, false
+	}
+	total, err = strconv.ParseInt(rangeAndTotal[1], 10, 64)
+	if err != nil || total <= end {
+		return 0, 0, 0, false
+	}
+	return start, end, total, true
+}

--- a/app/download.go
+++ b/app/download.go
@@ -1,20 +1,25 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 )
 
 const (
 	downloadPhaseTransfer = "download"
 	downloadPhaseVerify   = "verify"
+	commitRenameAttempts  = 15
+	commitRenameDelay     = 500 * time.Millisecond
 )
 
 type downloadProgress func(phase string, done, total int64)
@@ -260,10 +265,42 @@ func verifyAndCommitPart(tmp, dest, wantSum string, progress downloadProgress) (
 	if err != nil || !ok {
 		return ok, err
 	}
-	if err := os.Rename(tmp, dest); err != nil {
+	if err := renameDownloadedPart(tmp, dest, os.Rename, retryableRenameError, sleepDuringSetup); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func renameDownloadedPart(tmp, dest string, rename func(string, string) error, retryable func(error) bool, sleep func(time.Duration) error) error {
+	var renameErr error
+	for attempt := 1; attempt <= commitRenameAttempts; attempt++ {
+		if err := checkSetupCancelled(); err != nil {
+			return err
+		}
+		if renameErr = rename(tmp, dest); renameErr == nil {
+			return nil
+		}
+		if !retryable(renameErr) || attempt == commitRenameAttempts {
+			return renameErr
+		}
+		if err := sleep(commitRenameDelay); err != nil {
+			return err
+		}
+	}
+	return renameErr
+}
+
+func retryableRenameError(err error) bool {
+	return runtime.GOOS == "windows" && retryableWindowsRenameError(err)
+}
+
+func retryableWindowsRenameError(err error) bool {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+	// ERROR_ACCESS_DENIED, ERROR_SHARING_VIOLATION, ERROR_LOCK_VIOLATION.
+	return errno == 5 || errno == 32 || errno == 33
 }
 
 func copyDownloadBody(body io.ReadCloser, dst io.Writer, offset, total int64, progress downloadProgress, idleTimeout time.Duration) (int64, bool, error) {

--- a/app/download_test.go
+++ b/app/download_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -427,6 +428,86 @@ func TestDownloadVerifiedRejectsChecksumMismatch(t *testing.T) {
 	}
 	if _, err := os.Stat(dest + ".part"); !os.IsNotExist(err) {
 		t.Fatalf("bad partial was retained: %v", err)
+	}
+}
+
+func TestRenameDownloadedPartRetriesTransientWindowsError(t *testing.T) {
+	transientErr := &os.LinkError{Op: "rename", Old: "payload.part", New: "payload", Err: syscall.Errno(32)}
+	attempts := 0
+	sleeps := 0
+	err := renameDownloadedPart("payload.part", "payload", func(string, string) error {
+		attempts++
+		if attempts < 3 {
+			return transientErr
+		}
+		return nil
+	}, retryableWindowsRenameError, func(delay time.Duration) error {
+		sleeps++
+		if delay != commitRenameDelay {
+			t.Fatalf("retry delay = %s, want %s", delay, commitRenameDelay)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 3 || sleeps != 2 {
+		t.Fatalf("attempts = %d, sleeps = %d; want 3 attempts and 2 sleeps", attempts, sleeps)
+	}
+}
+
+func TestRenameDownloadedPartFailsNonTransientErrorImmediately(t *testing.T) {
+	wantErr := &os.LinkError{Op: "rename", Old: "payload.part", New: "payload", Err: syscall.Errno(2)}
+	attempts := 0
+	sleeps := 0
+	err := renameDownloadedPart("payload.part", "payload", func(string, string) error {
+		attempts++
+		return wantErr
+	}, retryableWindowsRenameError, func(time.Duration) error {
+		sleeps++
+		return nil
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if attempts != 1 || sleeps != 0 {
+		t.Fatalf("attempts = %d, sleeps = %d; want 1 attempt and no sleep", attempts, sleeps)
+	}
+}
+
+func TestRenameDownloadedPartBoundsTransientRetries(t *testing.T) {
+	wantErr := &os.LinkError{Op: "rename", Old: "payload.part", New: "payload", Err: syscall.Errno(5)}
+	attempts := 0
+	sleeps := 0
+	err := renameDownloadedPart("payload.part", "payload", func(string, string) error {
+		attempts++
+		return wantErr
+	}, retryableWindowsRenameError, func(time.Duration) error {
+		sleeps++
+		return nil
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if attempts != commitRenameAttempts || sleeps != commitRenameAttempts-1 {
+		t.Fatalf("attempts = %d, sleeps = %d; want %d attempts and %d sleeps", attempts, sleeps, commitRenameAttempts, commitRenameAttempts-1)
+	}
+}
+
+func TestRenameDownloadedPartCancelsRetryDelay(t *testing.T) {
+	wantErr := &os.LinkError{Op: "rename", Old: "payload.part", New: "payload", Err: syscall.Errno(33)}
+	attempts := 0
+	err := renameDownloadedPart("payload.part", "payload", func(string, string) error {
+		attempts++
+		return wantErr
+	}, retryableWindowsRenameError, func(time.Duration) error {
+		return errSetupCancelled
+	})
+	if !errors.Is(err, errSetupCancelled) {
+		t.Fatalf("error = %v, want setup cancellation", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
 	}
 }
 

--- a/app/download_test.go
+++ b/app/download_test.go
@@ -1,0 +1,443 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func fastDownloadOptions() downloadOptions {
+	return downloadOptions{
+		maxAttempts: 3,
+		idleTimeout: 2 * time.Second,
+		retryDelay:  func(int) time.Duration { return 0 },
+	}
+}
+
+func runTestDownload(t *testing.T, client *http.Client, url string, payload []byte, prepare func(dest string)) string {
+	t.Helper()
+	dest := filepath.Join(t.TempDir(), "payload.bin")
+	if prepare != nil {
+		prepare(dest)
+	}
+	if err := downloadVerifiedWithOptions(client, url, dest, testSHA256(payload), nil, fastDownloadOptions()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(payload) {
+		t.Fatalf("downloaded %q, want %q", data, payload)
+	}
+	if _, err := os.Stat(dest + ".part"); !os.IsNotExist(err) {
+		t.Fatalf("partial file remains after commit: %v", err)
+	}
+	return dest
+}
+
+func TestDownloadVerifiedCleanResponse(t *testing.T) {
+	payload := []byte("complete payload")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Accept-Encoding"); got != "identity" {
+			t.Errorf("Accept-Encoding = %q, want identity", got)
+		}
+		w.Write(payload)
+	}))
+	defer server.Close()
+	runTestDownload(t, server.Client(), server.URL, payload, nil)
+}
+
+func TestDownloadVerifiedResumesPartialResponse(t *testing.T) {
+	payload := []byte("prefix plus the remaining payload")
+	prefixLength := 7
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantRange := fmt.Sprintf("bytes=%d-", prefixLength)
+		if got := r.Header.Get("Range"); got != wantRange {
+			t.Errorf("Range = %q, want %q", got, wantRange)
+			return
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", prefixLength, len(payload)-1, len(payload)))
+		w.WriteHeader(http.StatusPartialContent)
+		w.Write(payload[prefixLength:])
+	}))
+	defer server.Close()
+	runTestDownload(t, server.Client(), server.URL, payload, func(dest string) {
+		if err := os.WriteFile(dest+".part", payload[:prefixLength], 0o644); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestDownloadVerifiedRestartsWhenServerIgnoresRange(t *testing.T) {
+	payload := []byte("server returns the whole payload")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Range") == "" {
+			t.Error("resume request did not include Range")
+			return
+		}
+		w.Write(payload)
+	}))
+	defer server.Close()
+	runTestDownload(t, server.Client(), server.URL, payload, func(dest string) {
+		if err := os.WriteFile(dest+".part", []byte("old prefix"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestDownloadVerifiedRestartsAfterWrongContentRange(t *testing.T) {
+	payload := []byte("payload after a bad range response")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := requests.Add(1)
+		if request == 1 {
+			if r.Header.Get("Range") == "" {
+				t.Error("first request did not attempt a resume")
+				return
+			}
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", len(payload)-1, len(payload)))
+			w.WriteHeader(http.StatusPartialContent)
+			return
+		}
+		if got := r.Header.Get("Range"); got != "" {
+			t.Errorf("retry Range = %q, want a clean restart", got)
+			return
+		}
+		w.Write(payload)
+	}))
+	defer server.Close()
+	runTestDownload(t, server.Client(), server.URL, payload, func(dest string) {
+		if err := os.WriteFile(dest+".part", []byte("prefix"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if requests.Load() != 2 {
+		t.Fatalf("requests = %d, want 2", requests.Load())
+	}
+}
+
+func TestDownloadVerifiedRestartsAfterStalePartialChecksum(t *testing.T) {
+	payload := []byte("current payload bytes")
+	prefixLength := 7
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch requests.Add(1) {
+		case 1:
+			wantRange := fmt.Sprintf("bytes=%d-", prefixLength)
+			if got := r.Header.Get("Range"); got != wantRange {
+				t.Errorf("Range = %q, want %q", got, wantRange)
+				return
+			}
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", prefixLength, len(payload)-1, len(payload)))
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(payload[prefixLength:])
+		case 2:
+			if got := r.Header.Get("Range"); got != "" {
+				t.Errorf("clean restart Range = %q, want none", got)
+				return
+			}
+			_, _ = w.Write(payload)
+		default:
+			t.Error("unexpected extra request")
+		}
+	}))
+	defer server.Close()
+	dest := filepath.Join(t.TempDir(), "payload.bin")
+	if err := os.WriteFile(dest+".part", []byte("stale!!"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts := fastDownloadOptions()
+	opts.maxAttempts = 1
+	if err := downloadVerifiedWithOptions(server.Client(), server.URL, dest, testSHA256(payload), nil, opts); err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("requests = %d, want 2", requests.Load())
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(payload) {
+		t.Fatalf("downloaded %q, want %q", data, payload)
+	}
+}
+
+func TestDownloadVerifiedRetriesInterruptedResponse(t *testing.T) {
+	payload := []byte(strings.Repeat("resume me ", 64))
+	cut := len(payload) / 3
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := requests.Add(1)
+		if request == 1 {
+			w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+			w.WriteHeader(http.StatusOK)
+			w.Write(payload[:cut])
+			return
+		}
+		wantRange := fmt.Sprintf("bytes=%d-", cut)
+		if got := r.Header.Get("Range"); got != wantRange {
+			t.Errorf("retry Range = %q, want %q", got, wantRange)
+			return
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", cut, len(payload)-1, len(payload)))
+		w.WriteHeader(http.StatusPartialContent)
+		w.Write(payload[cut:])
+	}))
+	defer server.Close()
+	runTestDownload(t, server.Client(), server.URL, payload, nil)
+	if requests.Load() != 2 {
+		t.Fatalf("requests = %d, want 2", requests.Load())
+	}
+}
+
+func TestDownloadVerifiedRetainsPartialAcrossRuns(t *testing.T) {
+	payload := []byte(strings.Repeat("keep this partial ", 32))
+	cut := len(payload) / 2
+	dest := filepath.Join(t.TempDir(), "payload.bin")
+	interrupted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		w.WriteHeader(http.StatusOK)
+		w.Write(payload[:cut])
+	}))
+	opts := fastDownloadOptions()
+	opts.maxAttempts = 1
+	err := downloadVerifiedWithOptions(interrupted.Client(), interrupted.URL, dest, testSHA256(payload), nil, opts)
+	interrupted.Close()
+	if err == nil {
+		t.Fatal("interrupted response unexpectedly succeeded")
+	}
+	info, err := os.Stat(dest + ".part")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != int64(cut) {
+		t.Fatalf("partial size = %d, want %d", info.Size(), cut)
+	}
+
+	resumed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantRange := fmt.Sprintf("bytes=%d-", cut)
+		if got := r.Header.Get("Range"); got != wantRange {
+			t.Errorf("Range = %q, want %q", got, wantRange)
+			return
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", cut, len(payload)-1, len(payload)))
+		w.WriteHeader(http.StatusPartialContent)
+		w.Write(payload[cut:])
+	}))
+	defer resumed.Close()
+	if err := downloadVerifiedWithOptions(resumed.Client(), resumed.URL, dest, testSHA256(payload), nil, fastDownloadOptions()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(payload) {
+		t.Fatal("resumed payload does not match")
+	}
+}
+
+func TestDownloadVerifiedTimesOutIdleBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		time.Sleep(100 * time.Millisecond)
+		w.Write([]byte("x"))
+	}))
+	defer server.Close()
+	dest := filepath.Join(t.TempDir(), "payload.bin")
+	opts := fastDownloadOptions()
+	opts.maxAttempts = 1
+	opts.idleTimeout = 20 * time.Millisecond
+	err := downloadVerifiedWithOptions(server.Client(), server.URL, dest, testSHA256([]byte("x")), nil, opts)
+	if err == nil || !strings.Contains(err.Error(), "stalled") {
+		t.Fatalf("error = %v, want idle-stall failure", err)
+	}
+}
+
+func TestDownloadVerifiedCancelsActiveRequest(t *testing.T) {
+	configureSetupCancellation(false)
+	t.Cleanup(func() { configureSetupCancellation(false) })
+	started := make(chan struct{})
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		close(started)
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})}
+	result := make(chan error, 1)
+	go func() {
+		result <- downloadVerifiedWithOptions(client, "https://example.invalid/payload", filepath.Join(t.TempDir(), "payload.bin"),
+			testSHA256([]byte("payload")), nil, fastDownloadOptions())
+	}()
+	<-started
+	requestSetupCancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, errSetupCancelled) {
+			t.Fatalf("error = %v, want setup cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("active request did not stop after cancellation")
+	}
+}
+
+type blockingDownloadBody struct {
+	started chan struct{}
+	closed  chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingDownloadBody) Read([]byte) (int, error) {
+	b.once.Do(func() { close(b.started) })
+	<-b.closed
+	return 0, errors.New("body closed")
+}
+
+func (b *blockingDownloadBody) Close() error {
+	b.once.Do(func() { close(b.started) })
+	select {
+	case <-b.closed:
+	default:
+		close(b.closed)
+	}
+	return nil
+}
+
+func TestDownloadVerifiedCancelsBlockedBodyAndCleansPartial(t *testing.T) {
+	configureSetupCancellation(false)
+	t.Cleanup(func() { configureSetupCancellation(false) })
+	body := &blockingDownloadBody{started: make(chan struct{}), closed: make(chan struct{})}
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: 7,
+			Body:          body,
+			Header:        make(http.Header),
+		}, nil
+	})}
+	root := t.TempDir()
+	dest := filepath.Join(root, "payload.bin")
+	result := make(chan error, 1)
+	go func() {
+		result <- downloadVerifiedWithOptions(client, "https://example.invalid/payload", dest,
+			testSHA256([]byte("payload")), nil, fastDownloadOptions())
+	}()
+	<-body.started
+	requestSetupCancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, errSetupCancelled) {
+			t.Fatalf("error = %v, want setup cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocked body read did not stop after cancellation")
+	}
+	if _, err := os.Stat(dest + ".part"); err != nil {
+		t.Fatalf("partial should remain until explicit-cancel cleanup: %v", err)
+	}
+	if err := cleanupCancelledSetup(root, filepath.Join(t.TempDir(), "TryOmarchy.exe"), false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dest + ".part"); !os.IsNotExist(err) {
+		t.Fatalf("explicit-cancel cleanup left partial behind: %v", err)
+	}
+}
+
+func TestDownloadVerifiedCancelsRetryDelay(t *testing.T) {
+	configureSetupCancellation(false)
+	t.Cleanup(func() { configureSetupCancellation(false) })
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       io.NopCloser(strings.NewReader("retry")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	delayStarted := make(chan struct{})
+	opts := fastDownloadOptions()
+	opts.retryDelay = func(int) time.Duration {
+		close(delayStarted)
+		return time.Hour
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- downloadVerifiedWithOptions(client, "https://example.invalid/payload", filepath.Join(t.TempDir(), "payload.bin"),
+			testSHA256([]byte("payload")), nil, opts)
+	}()
+	<-delayStarted
+	requestSetupCancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, errSetupCancelled) {
+			t.Fatalf("error = %v, want setup cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("retry delay did not stop after cancellation")
+	}
+}
+
+func TestDownloadVerifiedCommitsCompletePartAfterRangeRejection(t *testing.T) {
+	payload := []byte("already complete")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantRange := fmt.Sprintf("bytes=%d-", len(payload))
+		if got := r.Header.Get("Range"); got != wantRange {
+			t.Errorf("Range = %q, want %q", got, wantRange)
+			return
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", len(payload)))
+		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+	}))
+	defer server.Close()
+	runTestDownload(t, server.Client(), server.URL, payload, func(dest string) {
+		if err := os.WriteFile(dest+".part", payload, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestDownloadVerifiedRejectsChecksumMismatch(t *testing.T) {
+	want := []byte("expected payload")
+	wrong := []byte("different bytes")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Write(wrong)
+	}))
+	defer server.Close()
+	dest := filepath.Join(t.TempDir(), "payload.bin")
+	err := downloadVerifiedWithOptions(server.Client(), server.URL, dest, testSHA256(want), nil, fastDownloadOptions())
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("error = %v, want checksum mismatch", err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("requests = %d, want 1", requests.Load())
+	}
+	if _, err := os.Stat(dest + ".part"); !os.IsNotExist(err) {
+		t.Fatalf("bad partial was retained: %v", err)
+	}
+}
+
+func TestParseContentRange(t *testing.T) {
+	start, end, total, ok := parseContentRange("bytes 10-19/100")
+	if !ok || start != 10 || end != 19 || total != 100 {
+		t.Fatalf("parsed (%d, %d, %d, %t)", start, end, total, ok)
+	}
+	for _, value := range []string{"", "items 1-2/3", "bytes */3", "bytes 2-1/3", "bytes 1-3/3"} {
+		if _, _, _, ok := parseContentRange(value); ok {
+			t.Errorf("accepted invalid Content-Range %q", value)
+		}
+	}
+}

--- a/app/fetch.go
+++ b/app/fetch.go
@@ -4,8 +4,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -86,7 +84,7 @@ func ensureGuestFiles(cfg *config, release, sumsSHA256 string) error {
 	}
 
 	ui := getUI()
-	client := &http.Client{Timeout: 0}
+	client := newDownloadClient()
 
 	sums, err := releaseSums(client, release, sumsSHA256)
 	if err != nil {
@@ -182,61 +180,18 @@ func removeCachedFile(path string) error {
 }
 
 func download(client *http.Client, url, dest, wantSum string, ui *progressUI) error {
-	if !validSHA256(wantSum) {
-		return fmt.Errorf("release manifest has no valid SHA256 for %s", filepath.Base(dest))
-	}
-	resp, err := getWithSetupRetry(client, url, 5)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("HTTP %d", resp.StatusCode)
-	}
-	tmp := dest + ".part"
-	f, err := os.Create(tmp)
-	if err != nil {
-		return err
-	}
-	h := sha256.New()
-	buf := make([]byte, 1<<20)
-	var done int64
-	for {
-		if err := checkSetupCancelled(); err != nil {
-			f.Close()
-			os.Remove(tmp)
-			return err
-		}
-		n, rerr := resp.Body.Read(buf)
-		if n > 0 {
-			if _, werr := f.Write(buf[:n]); werr != nil {
-				f.Close()
-				return werr
+	phase := ""
+	return downloadVerified(client, url, dest, wantSum, func(next string, done, total int64) {
+		if next != phase {
+			if next == downloadPhaseVerify {
+				ui.setStatus("Checking downloaded %s...", filepath.Base(dest))
+			} else if phase == downloadPhaseVerify {
+				ui.setStatus("Resuming %s...", filepath.Base(dest))
 			}
-			h.Write(buf[:n])
-			done += int64(n)
-			ui.setProgress(done, resp.ContentLength)
 		}
-		if rerr == io.EOF {
-			break
-		}
-		if rerr != nil {
-			f.Close()
-			return rerr
-		}
-	}
-	if err := f.Sync(); err != nil {
-		f.Close()
-		return err
-	}
-	if err := f.Close(); err != nil {
-		return err
-	}
-	if hex.EncodeToString(h.Sum(nil)) != wantSum {
-		os.Remove(tmp)
-		return fmt.Errorf("checksum mismatch - the download is corrupt, try again")
-	}
-	return os.Rename(tmp, dest)
+		phase = next
+		ui.setProgress(done, total)
+	})
 }
 
 func decompress(src, dest, wantSum string, ui *progressUI) error {

--- a/app/setup.go
+++ b/app/setup.go
@@ -6,7 +6,6 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -222,7 +221,7 @@ func ensureRuntime(cfg *config, release, sumsSHA256 string) (string, error) {
 	}
 	root := filepath.Join(cfg.dir, "runtime")
 	ui := getUI()
-	client := &http.Client{Timeout: 0}
+	client := newDownloadClient()
 	sums, err := releaseSums(client, release, sumsSHA256)
 	if err != nil {
 		return "", fmt.Errorf("authenticating SHA256SUMS: %w", err)


### PR DESCRIPTION
## Problem

The release payloads are large (the rootfs archive is about 1.4 GB). A transient disconnect currently leaves a `.part` file, but the next attempt starts again from byte zero, wasting time and bandwidth.

## Change

- reuse an existing `.part` file across attempts and launcher runs
- request the remaining bytes with HTTP `Range`
- append only after a strict `206 Partial Content` response whose `Content-Range` starts at the exact requested offset
- safely truncate and restart when a server ignores the range or returns invalid range metadata
- handle `416 Range Not Satisfiable` by authenticating a potentially complete staged file
- retry transient transport, `408`, `429`, and `5xx` failures with bounded backoff
- bound TLS handshakes, response headers, and body-idle stalls without imposing a total timeout on multi-gigabyte transfers
- verify the complete staged file against the authenticated SHA-256 before the atomic rename
- use the same verified download path for guest assets and the WINQ-EMU runtime
- document resumable transfers in the README

Tests cover clean downloads, valid resumes, ignored and malformed ranges, interrupted responses, cross-run partial reuse, idle-body timeouts, completed partials returning `416`, checksum rejection, and `Content-Range` parsing.

## Verification

Run from `app/`:

- `go test -race -cover ./...` — pass, 62.5% statement coverage
- `go vet ./...` — pass
- downloader and range tests repeated 20 times under the race detector — pass
- `GOOS=windows GOARCH=amd64 go test -c .` — pass
- `GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "-H windowsgui -s -w" .` — pass

## Limitation

I could cross-compile the Windows test binary and GUI executable here, but could not run an end-to-end interrupted download on physical Windows hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Downloads can resume after interruption using partial files when supported by the server.
  - Downloaded payloads are verified with SHA-256 checksums before use.
  - Added retries, cancellation support, progress updates, and connection and idle-transfer timeouts.
  - Completed downloads are published atomically to prevent incomplete files from being used.

- **Bug Fixes**
  - Invalid, incomplete, or checksum-mismatched downloads are safely restarted or rejected.
  - Improved reliability when finalizing downloads on Windows.

- **Documentation**
  - Added README guidance for resumable downloads and integrity verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->