### PR TITLE
Add authenticated offline portable mode for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ supports byte ranges, then the complete file is SHA256-verified before use.
 Custom release URLs must be paired with the
 trusted manifest digest via `-sums-sha256`.
 
+### Offline portable mode
+
+The launcher also accepts `-portable` for an experimental, persistent USB
+layout. In this mode it reads an authenticated release payload beside the
+executable, makes no setup-time network requests, stores all guest state on the
+removable drive, and uses a compact QCOW2 overlay that survives Windows drive
+letter changes and works on exFAT. The independently pinned `SHA256SUMS` digest,
+install receipts, cancellation handling, and atomic file publication apply to
+the portable path too.
+
+See [`docs/PORTABLE_USB.md`](docs/PORTABLE_USB.md) for the expected layout and
+host requirements. Bundle preparation and additional host launchers are kept
+out of this core Windows change so they can be reviewed separately.
+
 Or skip the app and drive QEMU from PowerShell: `scripts\bootstrap.ps1` then `scripts\launch-omarchy.ps1` (elevated).
 
 ## FAQ

--- a/app/fetch.go
+++ b/app/fetch.go
@@ -86,7 +86,7 @@ func ensureGuestFiles(cfg *config, release, sumsSHA256 string) error {
 	ui := getUI()
 	client := newDownloadClient()
 
-	sums, err := releaseSums(client, release, sumsSHA256)
+	sums, err := releaseSumsForConfig(cfg, client, release, sumsSHA256)
 	if err != nil {
 		return fmt.Errorf("authenticating SHA256SUMS: %w", err)
 	}
@@ -101,13 +101,25 @@ func ensureGuestFiles(cfg *config, release, sumsSHA256 string) error {
 			return err
 		}
 		dest := filepath.Join(cfg.guestDir, name)
-		if err := ensureVerifiedDownload(client, normalizedRelease(release)+"/"+name, dest, sums[name],
-			fmt.Sprintf("Downloading Omarchy (%d of %d)...", i+1, len(downloadedGuestArtifacts)+1), ui); err != nil {
-			return fmt.Errorf("preparing %s: %w", name, err)
+		status := fmt.Sprintf("Downloading Omarchy (%d of %d)...", i+1, len(downloadedGuestArtifacts)+1)
+		var installErr error
+		if cfg.portable {
+			status = fmt.Sprintf("Checking portable Omarchy (%d of %d)...", i+1, len(downloadedGuestArtifacts)+1)
+			installErr = ensureVerifiedPortableCopy(filepath.Join(cfg.payloadDir, name), dest, sums[name], status, ui)
+		} else {
+			installErr = ensureVerifiedDownload(client, normalizedRelease(release)+"/"+name, dest, sums[name], status, ui)
+		}
+		if installErr != nil {
+			return fmt.Errorf("preparing %s: %w", name, installErr)
 		}
 	}
 
 	zst := filepath.Join(cfg.guestDir, "rootfs.ext4.zst")
+	removeZst := true
+	if cfg.portable {
+		zst = filepath.Join(cfg.payloadDir, "rootfs.ext4.zst")
+		removeZst = false
+	}
 	rootfs := filepath.Join(cfg.guestDir, "rootfs.ext4")
 	if _, err := os.Lstat(rootfs); err == nil {
 		ui.setStatus("Checking the cached Omarchy system...")
@@ -120,7 +132,16 @@ func ensureGuestFiles(cfg *config, release, sumsSHA256 string) error {
 		if err := removeCachedFile(rootfs); err != nil {
 			return fmt.Errorf("removing incomplete rootfs.ext4: %w", err)
 		}
-		if err := ensureVerifiedDownload(client, normalizedRelease(release)+"/rootfs.ext4.zst", zst,
+		if cfg.portable {
+			ui.setStatus("Checking the portable Omarchy system...")
+			ok, err := verifyFileSHA256(zst, sums["rootfs.ext4.zst"], ui.setProgress)
+			if err != nil {
+				return fmt.Errorf("checking rootfs.ext4.zst: %w", err)
+			}
+			if !ok {
+				return fmt.Errorf("checksum mismatch for rootfs.ext4.zst")
+			}
+		} else if err := ensureVerifiedDownload(client, normalizedRelease(release)+"/rootfs.ext4.zst", zst,
 			sums["rootfs.ext4.zst"], fmt.Sprintf("Downloading Omarchy (%d of %d)...",
 				len(downloadedGuestArtifacts)+1, len(downloadedGuestArtifacts)+1), ui); err != nil {
 			return fmt.Errorf("preparing rootfs.ext4.zst: %w", err)
@@ -133,7 +154,9 @@ func ensureGuestFiles(cfg *config, release, sumsSHA256 string) error {
 	if err := writeInstallReceipt(cfg.guestDir, release, sumsSHA256, installedGuestArtifacts, sums); err != nil {
 		return fmt.Errorf("recording verified install state: %w", err)
 	}
-	os.Remove(zst) // 1.4 GB nobody needs twice
+	if removeZst {
+		os.Remove(zst) // 1.4 GB nobody needs twice
+	}
 	ui.setStatus("Ready - starting Omarchy...")
 	ui.setProgress(1, 1)
 	return sleepDuringSetup(700 * time.Millisecond)
@@ -149,6 +172,26 @@ func releaseVersion(release string) string {
 		return version
 	}
 	return currentVersion
+}
+
+func ensureVerifiedPortableCopy(src, dest, wantSum, status string, ui *progressUI) error {
+	if _, err := os.Lstat(dest); err == nil {
+		ui.setStatus("Checking cached %s...", filepath.Base(dest))
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	ok, err := verifyFileSHA256(dest, wantSum, ui.setProgress)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+	if err := removeCachedFile(dest); err != nil {
+		return err
+	}
+	ui.setStatus("%s", status)
+	return copyPortableArtifact(src, dest, wantSum, ui.setProgress)
 }
 
 func ensureVerifiedDownload(client *http.Client, url, dest, wantSum, status string, ui *progressUI) error {

--- a/app/main.go
+++ b/app/main.go
@@ -36,14 +36,17 @@ const (
 )
 
 type config struct {
-	dir, winqEmu, share                  string
-	fresh, fullscreen, noGpu, hostCursor bool
-	instant                              bool
-	guestDir, vmDir, disk                string
-	qemu                                 string
-	useGpu                               bool
-	audio                                string
-	memMiB                               int
+	dir, hostDir, payloadDir string
+	winqEmu, share           string
+	fresh, fullscreen, noGpu bool
+	hostCursor               bool
+	instant, portable        bool
+	guestDir, vmDir, disk    string
+	diskFormat               string
+	qemu                     string
+	useGpu                   bool
+	audio                    string
+	memMiB                   int
 }
 
 // pickGuestMem sizes the guest to the machine instead of demanding a fixed
@@ -133,6 +136,7 @@ func main() {
 	flag.BoolVar(&cfg.noGpu, "nogpu", false, "force CPU rendering even if WINQ-EMU is installed")
 	flag.BoolVar(&cfg.hostCursor, "host-cursor", false, "force the legacy Windows cursor over the guest")
 	flag.BoolVar(&cfg.instant, "instant", false, "skip first-boot questions and use the trial account")
+	flag.BoolVar(&cfg.portable, "portable", false, "run entirely from data and payload folders beside the executable")
 	noUpdate := flag.Bool("no-update", false, "do not check for launcher or guest updates")
 	updateURL := flag.String("update-url", defaultUpdateURL, "authenticated update manifest URL")
 	release := flag.String("release", defaultReleaseURL,
@@ -161,33 +165,53 @@ func main() {
 	if *enableWhp {
 		os.Exit(runDismEnable())
 	}
-	if *applyLauncherUpdateFlag || *applyLauncherRollbackFlag {
-		if err := applyLauncherUpdate(cfg.dir, *updateWaitPID, *updateRestartArgs, *applyLauncherRollbackFlag); err != nil {
-			errorBox("Try Omarchy could not finish applying its update.\n\n" + err.Error())
-			os.Exit(1)
+	if cfg.portable {
+		self, err := os.Executable()
+		if err != nil {
+			fatal("Cannot find the portable launcher: %v", err)
 		}
-		return
-	}
-	restartArgs, err := encodeRestartArgs(os.Args[1:])
-	if err != nil {
-		fatal("Could not preserve launcher arguments for updates: %v", err)
-	}
-	if rollingBack, recoverErr := recoverLauncherUpdate(cfg.dir, restartArgs); recoverErr != nil {
-		logf("launcher update recovery: %v", recoverErr)
-	} else if rollingBack {
-		return
+		root := filepath.Dir(self)
+		cfg.dir = filepath.Join(root, "data")
+		cfg.payloadDir = filepath.Join(root, "payload")
+		// WHP is a property of this Windows host, so its restart marker must
+		// not travel to another PC with the USB.
+		cfg.hostDir = filepath.Join(os.Getenv("LOCALAPPDATA"), "TryOmarchy", "portable-host")
+	} else {
+		cfg.hostDir = cfg.dir
+		if *applyLauncherUpdateFlag || *applyLauncherRollbackFlag {
+			if err := applyLauncherUpdate(cfg.dir, *updateWaitPID, *updateRestartArgs, *applyLauncherRollbackFlag); err != nil {
+				errorBox("Try Omarchy could not finish applying its update.\n\n" + err.Error())
+				os.Exit(1)
+			}
+			return
+		}
+		restartArgs, err := encodeRestartArgs(os.Args[1:])
+		if err != nil {
+			fatal("Could not preserve launcher arguments for updates: %v", err)
+		}
+		if rollingBack, recoverErr := recoverLauncherUpdate(cfg.dir, restartArgs); recoverErr != nil {
+			logf("launcher update recovery: %v", recoverErr)
+		} else if rollingBack {
+			return
+		}
 	}
 
 	cfg.guestDir = filepath.Join(cfg.dir, "guest")
 	cfg.vmDir = filepath.Join(cfg.dir, "vm")
+	cfg.diskFormat = "raw"
 	cfg.disk = filepath.Join(cfg.vmDir, "disk.raw")
+	if cfg.portable {
+		cfg.diskFormat = "qcow2"
+		cfg.disk = filepath.Join(cfg.vmDir, "disk.qcow2")
+	}
 	if _, err := rollbackPendingPayloadUpdates(cfg.dir); err != nil {
 		fatal("Could not recover the previous Omarchy files after an interrupted update: %v", err)
 	}
-	completeAtStart := completeInstallExists(cfg.dir)
+	completeAtStart := completeInstallExists(cfg.dir, filepath.Base(cfg.disk))
 	needsProvisioning := cfg.fresh || !completeAtStart
 	configureSetupCancellation(!completeAtStart)
 	os.MkdirAll(cfg.vmDir, 0o755)
+	os.MkdirAll(cfg.hostDir, 0o755)
 	logFile, _ = os.OpenFile(filepath.Join(cfg.vmDir, "shell.log"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if logFile != nil {
 		// A windowsgui process has no console: an unhandled panic (any
@@ -211,8 +235,7 @@ func main() {
 	// previous run must not be mistaken for this one's.
 	os.Remove(filepath.Join(cfg.vmDir, "qemu-stderr.log"))
 
-	if !*noUpdate && normalizedRelease(*release) == defaultReleaseURL &&
-		normalizedSHA256(*sumsSHA256) == defaultSumsSHA256 {
+	if automaticUpdatesEnabled(cfg, *noUpdate, *release, *sumsSHA256) {
 		checkDue := *updateURL != defaultUpdateURL || updateCheckDue(cfg.dir, time.Now())
 		if checkDue {
 			_ = recordUpdateCheck(cfg.dir, time.Now())
@@ -242,12 +265,15 @@ func main() {
 	const qemuExe = "qemu-system-x86_64w.exe"
 	stockQemu := `C:\Program Files\qemu\` + qemuExe
 	_, stockErr := os.Stat(stockQemu)
-	haveStock := stockErr == nil
+	haveStock := stockErr == nil && !cfg.portable
 	gpuRoot := ""
-	if _, err := os.Stat(filepath.Join(cfg.winqEmu, "bin", qemuExe)); err == nil {
-		// A user-managed WINQ-EMU install stays under the user's control. Only
-		// the bundled runtime under cfg.dir participates in automatic updates.
-		gpuRoot = cfg.winqEmu
+	if !cfg.portable {
+		_, err := os.Stat(filepath.Join(cfg.winqEmu, "bin", qemuExe))
+		if err == nil {
+			// A user-managed WINQ-EMU install stays under the user's control. Only
+			// the bundled runtime under cfg.dir participates in automatic updates.
+			gpuRoot = cfg.winqEmu
+		}
 	}
 	if gpuRoot == "" && !(cfg.noGpu && haveStock) {
 		root, err := ensureRuntime(cfg, *runtimeRelease, *runtimeSumsSHA256)
@@ -255,8 +281,11 @@ func main() {
 			if finishSetupCancellation(cfg, err) {
 				return
 			}
-			logf("runtime download failed: %v", err)
+			logf("runtime setup failed: %v", err)
 			if !haveStock {
+				if cfg.portable {
+					fatal("Setting up the portable graphics engine failed: %v\n\nThe USB payload may be missing or damaged.", err)
+				}
 				fatal("Downloading the graphics engine failed: %v\n\n%s", err, setupFailureHelp(err))
 			}
 		} else {
@@ -270,10 +299,14 @@ func main() {
 		cfg.qemu = stockQemu
 	}
 
-	// First run: the exe is the stub - fetch the guest image itself.
+	// First run: fetch the guest image, or copy and unpack the authenticated
+	// local payload. Portable mode never falls back to the network.
 	if err := ensureGuest(cfg, *release, *sumsSHA256); err != nil {
 		if finishSetupCancellation(cfg, err) {
 			return
+		}
+		if cfg.portable {
+			fatal("Setting up portable Omarchy failed: %v\n\nThe USB payload may be missing or damaged.", err)
 		}
 		fatal("Setting up the Omarchy image failed: %v\n\n%s", err, setupFailureHelp(err))
 	}
@@ -316,7 +349,11 @@ func main() {
 	if finishSetupCancellation(cfg, checkSetupCancelled()) {
 		return
 	}
-	offerLauncherShortcuts(cfg.dir)
+	// A shortcut to a copied portable executable would lose its sibling
+	// payload and defeat portability. The USB launcher remains the entrypoint.
+	if !cfg.portable {
+		offerLauncherShortcuts(cfg.dir)
+	}
 	if finishSetupCancellation(cfg, checkSetupCancelled()) {
 		return
 	}

--- a/app/portable.go
+++ b/app/portable.go
@@ -8,6 +8,12 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
+)
+
+const (
+	portableRenameAttempts = 15
+	portableRenameDelay    = 200 * time.Millisecond
 )
 
 func automaticUpdatesEnabled(cfg *config, noUpdate bool, release, sumsSHA256 string) bool {
@@ -142,9 +148,42 @@ func copyPortableArtifact(src, dest, want string, progress func(done, total int6
 	if err := out.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tmp, dest); err != nil {
+	if err := renamePortableFileWithRetry(tmp, dest); err != nil {
 		return err
 	}
 	ok = true
 	return nil
+}
+
+// renamePortableFileWithRetry tolerates short-lived file locks from Defender
+// and indexers while keeping publication bounded and setup cancellation-aware.
+func renamePortableFileWithRetry(from, to string) error {
+	return renamePortableFileWith(
+		from,
+		to,
+		os.Rename,
+		sleepDuringSetup,
+	)
+}
+
+func renamePortableFileWith(
+	from, to string,
+	rename func(string, string) error,
+	sleep func(time.Duration) error,
+) error {
+	var renameErr error
+	for attempt := 0; attempt < portableRenameAttempts; attempt++ {
+		if err := checkSetupCancelled(); err != nil {
+			return err
+		}
+		if renameErr = rename(from, to); renameErr == nil {
+			return nil
+		}
+		if attempt+1 < portableRenameAttempts {
+			if err := sleep(portableRenameDelay); err != nil {
+				return err
+			}
+		}
+	}
+	return renameErr
 }

--- a/app/portable.go
+++ b/app/portable.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+func automaticUpdatesEnabled(cfg *config, noUpdate bool, release, sumsSHA256 string) bool {
+	return !cfg.portable && !noUpdate &&
+		normalizedRelease(release) == defaultReleaseURL &&
+		normalizedSHA256(sumsSHA256) == defaultSumsSHA256
+}
+
+func releaseSumsForConfig(cfg *config, client *http.Client, release, expectedSHA256 string) (map[string]string, error) {
+	if !cfg.portable {
+		return releaseSums(client, release, expectedSHA256)
+	}
+	return readPortableManifest(filepath.Join(cfg.payloadDir, "SHA256SUMS"), expectedSHA256)
+}
+
+// readPortableManifest applies the same independent trust root and structural
+// limits as the online path. A manifest travelling beside the payload is not
+// trusted merely because both files are on the same USB.
+func readPortableManifest(path, expectedSHA256 string) (map[string]string, error) {
+	if err := checkSetupCancelled(); err != nil {
+		return nil, err
+	}
+	before, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !before.Mode().IsRegular() {
+		return nil, fmt.Errorf("portable SHA256SUMS is not a regular file")
+	}
+	if before.Size() > maxSumsBytes {
+		return nil, fmt.Errorf("SHA256SUMS exceeds %d bytes", maxSumsBytes)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(setupReader{r: f}, maxSumsBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxSumsBytes {
+		return nil, fmt.Errorf("SHA256SUMS exceeds %d bytes", maxSumsBytes)
+	}
+	after, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) != before.Size() || after.Size() != before.Size() ||
+		after.ModTime().UnixNano() != before.ModTime().UnixNano() {
+		return nil, fmt.Errorf("portable SHA256SUMS changed while being read")
+	}
+	return parseVerifiedSums(data, expectedSHA256)
+}
+
+// copyPortableArtifact verifies while copying into a sibling staging file,
+// flushes it, and only then publishes the destination. Cancellation or a bad
+// checksum cannot leave a file under its final name.
+func copyPortableArtifact(src, dest, want string, progress func(done, total int64)) error {
+	want = normalizedSHA256(want)
+	if !validSHA256(want) {
+		return fmt.Errorf("release manifest has no valid SHA256 for %s", filepath.Base(src))
+	}
+	before, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if !before.Mode().IsRegular() {
+		return fmt.Errorf("portable payload is not a regular file: %s", filepath.Base(src))
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	tmp := dest + ".part"
+	if err := os.Remove(tmp); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	ok := false
+	defer func() {
+		if !ok {
+			out.Close()
+			os.Remove(tmp)
+		}
+	}()
+	h := sha256.New()
+	buf := make([]byte, 1<<20)
+	var done int64
+	for {
+		if err := checkSetupCancelled(); err != nil {
+			return err
+		}
+		n, readErr := in.Read(buf)
+		if n > 0 {
+			if _, err := out.Write(buf[:n]); err != nil {
+				return err
+			}
+			if _, err := h.Write(buf[:n]); err != nil {
+				return err
+			}
+			done += int64(n)
+			if progress != nil {
+				progress(done, before.Size())
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+	after, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	if done != before.Size() || after.Size() != before.Size() ||
+		after.ModTime().UnixNano() != before.ModTime().UnixNano() {
+		return fmt.Errorf("portable payload changed while being copied: %s", filepath.Base(src))
+	}
+	if hex.EncodeToString(h.Sum(nil)) != want {
+		return fmt.Errorf("checksum mismatch for %s", filepath.Base(src))
+	}
+	if err := out.Sync(); err != nil {
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		return err
+	}
+	ok = true
+	return nil
+}

--- a/app/portable_test.go
+++ b/app/portable_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestPortableModeDisablesAutomaticUpdates(t *testing.T) {
@@ -105,5 +107,87 @@ func TestCopyPortableArtifactHonorsCancellation(t *testing.T) {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("cancelled copy published %s: %v", path, err)
 		}
+	}
+}
+
+func TestRenamePortableFileRetriesTemporaryLocks(t *testing.T) {
+	configureSetupCancellation(false)
+	attempts := 0
+	waits := 0
+	err := renamePortableFileWith(
+		"staged",
+		"published",
+		func(from, to string) error {
+			attempts++
+			if from != "staged" || to != "published" {
+				t.Fatalf("rename paths = %q, %q", from, to)
+			}
+			if attempts < 3 {
+				return errors.New("temporarily locked")
+			}
+			return nil
+		},
+		func(delay time.Duration) error {
+			waits++
+			if delay != portableRenameDelay {
+				t.Fatalf("retry delay = %s", delay)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 3 || waits != 2 {
+		t.Fatalf("attempts = %d, waits = %d", attempts, waits)
+	}
+}
+
+func TestRenamePortableFileStopsAfterBound(t *testing.T) {
+	configureSetupCancellation(false)
+	want := errors.New("still locked")
+	attempts := 0
+	waits := 0
+	err := renamePortableFileWith(
+		"staged",
+		"published",
+		func(string, string) error {
+			attempts++
+			return want
+		},
+		func(time.Duration) error {
+			waits++
+			return nil
+		},
+	)
+	if !errors.Is(err, want) {
+		t.Fatalf("rename error = %v", err)
+	}
+	if attempts != portableRenameAttempts || waits != portableRenameAttempts-1 {
+		t.Fatalf("attempts = %d, waits = %d", attempts, waits)
+	}
+}
+
+func TestRenamePortableFileHonorsCancellation(t *testing.T) {
+	configureSetupCancellation(false)
+	t.Cleanup(func() { configureSetupCancellation(false) })
+	attempts := 0
+	err := renamePortableFileWith(
+		"staged",
+		"published",
+		func(string, string) error {
+			attempts++
+			return errors.New("temporarily locked")
+		},
+		func(time.Duration) error {
+			requestSetupCancel()
+			return checkSetupCancelled()
+		},
+	)
+	if !errors.Is(err, errSetupCancelled) {
+		t.Fatalf("rename error = %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts after cancellation = %d", attempts)
 	}
 }

--- a/app/portable_test.go
+++ b/app/portable_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPortableModeDisablesAutomaticUpdates(t *testing.T) {
+	cfg := &config{portable: true}
+	if automaticUpdatesEnabled(cfg, false, defaultReleaseURL, defaultSumsSHA256) {
+		t.Fatal("portable mode enabled the automatic-update network path")
+	}
+	cfg.portable = false
+	if !automaticUpdatesEnabled(cfg, false, defaultReleaseURL, defaultSumsSHA256) {
+		t.Fatal("standard mode disabled authenticated automatic updates")
+	}
+	if automaticUpdatesEnabled(cfg, true, defaultReleaseURL, defaultSumsSHA256) {
+		t.Fatal("-no-update did not disable automatic updates")
+	}
+}
+
+func TestPortableManifestUsesPinnedDigestWithoutNetwork(t *testing.T) {
+	configureSetupCancellation(false)
+	payload := t.TempDir()
+	data := []byte(testSHA256([]byte("artifact")) + "  artifact.bin\n")
+	if err := os.WriteFile(filepath.Join(payload, "SHA256SUMS"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config{portable: true, payloadDir: payload}
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("portable manifest attempted a network request")
+		return nil, nil
+	})}
+	sums, err := releaseSumsForConfig(cfg, client, defaultReleaseURL, testSHA256(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sums["artifact.bin"] != testSHA256([]byte("artifact")) {
+		t.Fatal("portable manifest did not return the authenticated entry")
+	}
+	if _, err := releaseSumsForConfig(cfg, client, defaultReleaseURL, testSHA256([]byte("tampered"))); err == nil {
+		t.Fatal("portable manifest was accepted with the wrong trust root")
+	}
+}
+
+func TestCopyPortableArtifactPublishesAtomically(t *testing.T) {
+	configureSetupCancellation(false)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "payload")
+	dest := filepath.Join(dir, "installed")
+	data := []byte("verified portable artifact")
+	if err := os.WriteFile(src, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyPortableArtifact(src, dest, testSHA256(data), nil); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("installed data = %q", got)
+	}
+	if _, err := os.Stat(dest + ".part"); !os.IsNotExist(err) {
+		t.Fatalf("staging file remains: %v", err)
+	}
+}
+
+func TestCopyPortableArtifactRejectsBadChecksum(t *testing.T) {
+	configureSetupCancellation(false)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "payload")
+	dest := filepath.Join(dir, "installed")
+	if err := os.WriteFile(src, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyPortableArtifact(src, dest, testSHA256([]byte("different")), nil); err == nil {
+		t.Fatal("bad checksum was accepted")
+	}
+	for _, path := range []string{dest, dest + ".part"} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("failed copy published %s: %v", path, err)
+		}
+	}
+}
+
+func TestCopyPortableArtifactHonorsCancellation(t *testing.T) {
+	configureSetupCancellation(false)
+	t.Cleanup(func() { configureSetupCancellation(false) })
+	dir := t.TempDir()
+	src := filepath.Join(dir, "payload")
+	dest := filepath.Join(dir, "installed")
+	data := []byte("payload")
+	if err := os.WriteFile(src, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	requestSetupCancel()
+	if err := copyPortableArtifact(src, dest, testSHA256(data), nil); err == nil {
+		t.Fatal("cancelled copy succeeded")
+	}
+	for _, path := range []string{dest, dest + ".part"} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("cancelled copy published %s: %v", path, err)
+		}
+	}
+}

--- a/app/qcow2.go
+++ b/app/qcow2.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	qcow2ClusterBits = 16
+	qcow2ClusterSize = int64(1 << qcow2ClusterBits)
+	qcow2HeaderSize  = 104
+)
+
+// createQcow2Overlay writes the small amount of QCOW2 v3 metadata needed for
+// an empty overlay backed by a raw image. QEMU allocates data and L2 tables as
+// the guest writes, avoiding an NTFS-only sparse raw copy on removable media.
+func createQcow2Overlay(path, backing string, virtualSize int64) (err error) {
+	if virtualSize <= 0 {
+		return fmt.Errorf("invalid virtual size %d", virtualSize)
+	}
+	if len(backing) == 0 || len(backing) > int(qcow2ClusterSize-qcow2HeaderSize) {
+		return fmt.Errorf("invalid backing path length %d", len(backing))
+	}
+	l1Coverage := qcow2ClusterSize * (qcow2ClusterSize / 8)
+	l1Size := (virtualSize + l1Coverage - 1) / l1Coverage
+	l1Bytes := l1Size * 8
+	l1Clusters := (l1Bytes + qcow2ClusterSize - 1) / qcow2ClusterSize
+	if l1Clusters <= 0 || l1Clusters > qcow2ClusterSize/2-3 {
+		return fmt.Errorf("virtual disk is too large")
+	}
+	const (
+		refcountTableOffset = qcow2ClusterSize
+		refcountBlockOffset = 2 * qcow2ClusterSize
+		l1TableOffset       = 3 * qcow2ClusterSize
+	)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := f.Close(); err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			os.Remove(path)
+		}
+	}()
+	header := make([]byte, qcow2HeaderSize)
+	binary.BigEndian.PutUint32(header[0:4], 0x514649fb)
+	binary.BigEndian.PutUint32(header[4:8], 3)
+	binary.BigEndian.PutUint64(header[8:16], qcow2HeaderSize)
+	binary.BigEndian.PutUint32(header[16:20], uint32(len(backing)))
+	binary.BigEndian.PutUint32(header[20:24], qcow2ClusterBits)
+	binary.BigEndian.PutUint64(header[24:32], uint64(virtualSize))
+	binary.BigEndian.PutUint32(header[36:40], uint32(l1Size))
+	binary.BigEndian.PutUint64(header[40:48], uint64(l1TableOffset))
+	binary.BigEndian.PutUint64(header[48:56], uint64(refcountTableOffset))
+	binary.BigEndian.PutUint32(header[56:60], 1)
+	binary.BigEndian.PutUint32(header[96:100], 4)
+	binary.BigEndian.PutUint32(header[100:104], qcow2HeaderSize)
+	if _, err = f.WriteAt(header, 0); err != nil {
+		return err
+	}
+	if _, err = f.WriteAt([]byte(backing), qcow2HeaderSize); err != nil {
+		return err
+	}
+	entry := make([]byte, 8)
+	binary.BigEndian.PutUint64(entry, uint64(refcountBlockOffset))
+	if _, err = f.WriteAt(entry, refcountTableOffset); err != nil {
+		return err
+	}
+	refcount := make([]byte, 2*(3+l1Clusters))
+	for i := int64(0); i < 3+l1Clusters; i++ {
+		binary.BigEndian.PutUint16(refcount[i*2:i*2+2], 1)
+	}
+	if _, err = f.WriteAt(refcount, refcountBlockOffset); err != nil {
+		return err
+	}
+	if err = f.Truncate(l1TableOffset + l1Bytes); err != nil {
+		return err
+	}
+	return f.Sync()
+}
+
+func qcow2OverlayMatches(path, backing string, virtualSize int64) (bool, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.Mode().IsRegular() {
+		return false, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	header := make([]byte, qcow2HeaderSize)
+	if _, err := io.ReadFull(f, header); err != nil {
+		return false, nil
+	}
+	if binary.BigEndian.Uint32(header[0:4]) != 0x514649fb ||
+		binary.BigEndian.Uint32(header[4:8]) != 3 ||
+		binary.BigEndian.Uint64(header[8:16]) != qcow2HeaderSize ||
+		binary.BigEndian.Uint32(header[20:24]) != qcow2ClusterBits ||
+		binary.BigEndian.Uint64(header[24:32]) != uint64(virtualSize) {
+		return false, nil
+	}
+	backingLen := int(binary.BigEndian.Uint32(header[16:20]))
+	if backingLen != len(backing) {
+		return false, nil
+	}
+	backingData := make([]byte, backingLen)
+	if _, err := f.ReadAt(backingData, qcow2HeaderSize); err != nil {
+		return false, nil
+	}
+	return string(backingData) == backing, nil
+}

--- a/app/qcow2_test.go
+++ b/app/qcow2_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateQcow2Overlay(t *testing.T) {
+	configureSetupCancellation(false)
+	root := t.TempDir()
+	guest := filepath.Join(root, "guest")
+	vm := filepath.Join(root, "vm")
+	if err := os.MkdirAll(guest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(vm, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(guest, "rootfs.ext4"), make([]byte, 4096), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	disk := filepath.Join(vm, "disk.qcow2")
+	cfg := &config{portable: true, guestDir: guest, vmDir: vm, disk: disk, diskFormat: "qcow2"}
+	const virtualMiB = int64(24 * 1024)
+	if err := prepareDisk(cfg, virtualMiB); err != nil {
+		t.Fatal(err)
+	}
+	const virtualSize = virtualMiB * 1024 * 1024
+	ok, err := qcow2OverlayMatches(disk, "../guest/rootfs.ext4", virtualSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("published QCOW2 metadata does not match")
+	}
+	if _, err := os.Stat(disk + ".part"); !os.IsNotExist(err) {
+		t.Fatalf("staging file remains: %v", err)
+	}
+	if qemuImg := os.Getenv("QEMU_IMG"); qemuImg != "" {
+		out, err := exec.Command(qemuImg, "info", "--output=json", "--backing-chain", disk).Output()
+		if err != nil {
+			t.Fatalf("qemu-img rejected overlay: %v", err)
+		}
+		var chain []struct {
+			Format      string `json:"format"`
+			VirtualSize int64  `json:"virtual-size"`
+		}
+		if err := json.Unmarshal(out, &chain); err != nil {
+			t.Fatal(err)
+		}
+		if len(chain) != 2 || chain[0].Format != "qcow2" || chain[0].VirtualSize != virtualSize {
+			t.Fatalf("unexpected backing chain: %+v", chain)
+		}
+		if out, err := exec.Command(qemuImg, "check", "-f", "qcow2", disk).CombinedOutput(); err != nil {
+			t.Fatalf("qemu-img found invalid metadata: %v (%s)", err, out)
+		}
+	}
+}
+
+func TestPortableDiskQuarantinesInvalidFinalFile(t *testing.T) {
+	configureSetupCancellation(false)
+	dir := t.TempDir()
+	vm := filepath.Join(dir, "vm")
+	if err := os.MkdirAll(vm, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	disk := filepath.Join(vm, "disk.qcow2")
+	if err := os.WriteFile(disk, []byte("partial"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config{portable: true, vmDir: vm, disk: disk, diskFormat: "qcow2"}
+	if err := prepareDisk(cfg, 1); err != nil {
+		t.Fatal(err)
+	}
+	matches, err := filepath.Glob(disk + ".incomplete-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("quarantined disks = %d, want 1", len(matches))
+	}
+}

--- a/app/qemu.go
+++ b/app/qemu.go
@@ -47,7 +47,7 @@ func buildQemuArgs(cfg *config, cmdline string) []string {
 		)
 	}
 	args = append(args,
-		"-drive", "file="+cfg.disk+",format=raw,if=virtio",
+		"-drive", "file="+cfg.disk+",format="+cfg.diskFormat+",if=virtio",
 		"-kernel", filepath.Join(cfg.guestDir, "vmlinuz-linux"),
 		"-initrd", filepath.Join(cfg.guestDir, "initramfs-linux.img"),
 		"-append", cmdline,
@@ -112,6 +112,9 @@ func prepareDisk(cfg *config, expandedMiB int64) error {
 			return fmt.Errorf("discarding the existing disk: %w", err)
 		}
 	}
+	if cfg.portable {
+		return preparePortableDisk(cfg, expandedBytes)
+	}
 	if info, err := os.Stat(cfg.disk); err == nil {
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("disk path is not a regular file: %s", cfg.disk)
@@ -174,5 +177,51 @@ func prepareDisk(cfg *config, expandedMiB int64) error {
 		return err
 	}
 	complete = true
+	return nil
+}
+
+// preparePortableDisk publishes a compact QCOW2 overlay through a sibling
+// staging file. Its backing path is relative so drive-letter changes do not
+// break it, and an interrupted creation never appears under the final name.
+func preparePortableDisk(cfg *config, expandedBytes int64) error {
+	backing := filepath.ToSlash(filepath.Join("..", "guest", "rootfs.ext4"))
+	ok, err := qcow2OverlayMatches(cfg.disk, backing, expandedBytes)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+	if info, statErr := os.Lstat(cfg.disk); statErr == nil {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("disk path is not a regular file: %s", cfg.disk)
+		}
+		quarantine := fmt.Sprintf("%s.incomplete-%d", cfg.disk, time.Now().UnixNano())
+		if err := os.Rename(cfg.disk, quarantine); err != nil {
+			return fmt.Errorf("quarantining incomplete disk: %w", err)
+		}
+	} else if !os.IsNotExist(statErr) {
+		return statErr
+	}
+	tmp := cfg.disk + ".part"
+	if err := os.Remove(tmp); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing stale disk staging file: %w", err)
+	}
+	if err := createQcow2Overlay(tmp, backing, expandedBytes); err != nil {
+		return fmt.Errorf("creating compact USB disk: %w", err)
+	}
+	published := false
+	defer func() {
+		if !published {
+			os.Remove(tmp)
+		}
+	}()
+	if err := checkSetupCancelled(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, cfg.disk); err != nil {
+		return err
+	}
+	published = true
 	return nil
 }

--- a/app/qemu.go
+++ b/app/qemu.go
@@ -219,7 +219,7 @@ func preparePortableDisk(cfg *config, expandedBytes int64) error {
 	if err := checkSetupCancelled(); err != nil {
 		return err
 	}
-	if err := os.Rename(tmp, cfg.disk); err != nil {
+	if err := renamePortableFileWithRetry(tmp, cfg.disk); err != nil {
 		return err
 	}
 	published = true

--- a/app/qemu_nonwindows_test.go
+++ b/app/qemu_nonwindows_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -17,14 +18,17 @@ const (
 )
 
 type config struct {
-	dir, winqEmu, share                  string
-	fresh, fullscreen, noGpu, hostCursor bool
-	instant                              bool
-	guestDir, vmDir, disk                string
-	qemu                                 string
-	useGpu                               bool
-	audio                                string
-	memMiB                               int
+	dir, hostDir, payloadDir string
+	winqEmu, share           string
+	fresh, fullscreen, noGpu bool
+	hostCursor               bool
+	instant, portable        bool
+	guestDir, vmDir, disk    string
+	diskFormat               string
+	qemu                     string
+	useGpu                   bool
+	audio                    string
+	memMiB                   int
 }
 
 type progressUI struct{}
@@ -52,7 +56,7 @@ func TestPrepareDiskPublishesCompleteFile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(guestDir, "rootfs.ext4"), []byte("factory rootfs"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cfg := &config{guestDir: guestDir, vmDir: vmDir, disk: filepath.Join(vmDir, "disk.raw")}
+	cfg := &config{guestDir: guestDir, vmDir: vmDir, disk: filepath.Join(vmDir, "disk.raw"), diskFormat: "raw"}
 	if err := prepareDisk(cfg, 1); err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +101,7 @@ func TestPrepareDiskQuarantinesLegacyPartialFile(t *testing.T) {
 	if err := os.WriteFile(disk, []byte("partial"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cfg := &config{guestDir: guestDir, vmDir: vmDir, disk: disk}
+	cfg := &config{guestDir: guestDir, vmDir: vmDir, disk: disk, diskFormat: "raw"}
 	if err := prepareDisk(cfg, 1); err != nil {
 		t.Fatal(err)
 	}
@@ -114,5 +118,20 @@ func TestPrepareDiskQuarantinesLegacyPartialFile(t *testing.T) {
 	}
 	if string(data) != "partial" {
 		t.Fatalf("quarantined content = %q, want partial", data)
+	}
+}
+
+func TestBuildQemuArgsUsesConfiguredDiskFormat(t *testing.T) {
+	cfg := &config{
+		vmDir:      "/usb/data/vm",
+		guestDir:   "/usb/data/guest",
+		disk:       "/usb/data/vm/disk.qcow2",
+		diskFormat: "qcow2",
+		memMiB:     4096,
+		audio:      "none",
+	}
+	args := strings.Join(buildQemuArgs(cfg, "root=/dev/vda"), " ")
+	if !strings.Contains(args, "file=/usb/data/vm/disk.qcow2,format=qcow2,if=virtio") {
+		t.Fatalf("configured disk format missing from QEMU args: %s", args)
 	}
 }

--- a/app/setup.go
+++ b/app/setup.go
@@ -169,7 +169,7 @@ func ensureWHP(cfg *config) {
 	if whpPresent() {
 		return
 	}
-	marker := filepath.Join(cfg.dir, "whp-requested")
+	marker := filepath.Join(cfg.hostDir, "whp-requested")
 	if st, err := os.Stat(marker); err == nil {
 		// The feature was already enabled on an earlier run. If the machine
 		// has rebooted since and the hypervisor is still absent, dism did its
@@ -222,7 +222,7 @@ func ensureRuntime(cfg *config, release, sumsSHA256 string) (string, error) {
 	root := filepath.Join(cfg.dir, "runtime")
 	ui := getUI()
 	client := newDownloadClient()
-	sums, err := releaseSums(client, release, sumsSHA256)
+	sums, err := releaseSumsForConfig(cfg, client, release, sumsSHA256)
 	if err != nil {
 		return "", fmt.Errorf("authenticating SHA256SUMS: %w", err)
 	}
@@ -250,7 +250,19 @@ func ensureRuntime(cfg *config, release, sumsSHA256 string) (string, error) {
 	}
 	updating := executableErr == nil
 	zipPath := filepath.Join(cfg.dir, runtimeZip)
-	if err := ensureVerifiedDownload(client, normalizedRelease(release)+"/"+runtimeZip, zipPath,
+	removeZip := true
+	if cfg.portable {
+		zipPath = filepath.Join(cfg.payloadDir, runtimeZip)
+		removeZip = false
+		ui.setStatus("Checking the portable graphics engine...")
+		ok, err := verifyFileSHA256(zipPath, sums[runtimeZip], ui.setProgress)
+		if err != nil {
+			return "", fmt.Errorf("checking %s: %w", runtimeZip, err)
+		}
+		if !ok {
+			return "", fmt.Errorf("checksum mismatch for %s", runtimeZip)
+		}
+	} else if err := ensureVerifiedDownload(client, normalizedRelease(release)+"/"+runtimeZip, zipPath,
 		archiveSHA, "Downloading the graphics engine...", ui); err != nil {
 		return "", fmt.Errorf("preparing %s: %w", runtimeZip, err)
 	}
@@ -262,7 +274,9 @@ func ensureRuntime(cfg *config, release, sumsSHA256 string) (string, error) {
 	os.RemoveAll(tmp)
 	if err := unzipTree(zipPath, tmp, ui); err != nil {
 		os.RemoveAll(tmp)
-		os.Remove(zipPath)
+		if removeZip {
+			os.Remove(zipPath)
+		}
 		return "", fmt.Errorf("unpacking %s: %w", runtimeZip, err)
 	}
 	if err := writeRuntimeReceipt(tmp, release, sumsSHA256, archiveSHA); err != nil {
@@ -298,7 +312,9 @@ func ensureRuntime(cfg *config, release, sumsSHA256 string) (string, error) {
 	if renameErr != nil {
 		return "", renameErr
 	}
-	os.Remove(zipPath)
+	if removeZip {
+		os.Remove(zipPath)
+	}
 	return root, nil
 }
 

--- a/app/setup_cancel.go
+++ b/app/setup_cancel.go
@@ -88,11 +88,11 @@ func (r setupReader) Read(p []byte) (int, error) {
 	return r.r.Read(p)
 }
 
-func completeInstallExists(dir string) bool {
+func completeInstallExists(dir, diskName string) bool {
 	for _, name := range []string{
 		filepath.Join("guest", "build-spec.json"),
 		filepath.Join("guest", "rootfs.ext4"),
-		filepath.Join("vm", "disk.raw"),
+		filepath.Join("vm", diskName),
 	} {
 		info, err := os.Stat(filepath.Join(dir, name))
 		if err != nil || !info.Mode().IsRegular() {

--- a/app/setup_cancel_test.go
+++ b/app/setup_cancel_test.go
@@ -104,7 +104,7 @@ func TestCleanupExistingInstallOnlyRemovesStagingFiles(t *testing.T) {
 
 func TestCompleteInstallDetection(t *testing.T) {
 	root := t.TempDir()
-	if completeInstallExists(root) {
+	if completeInstallExists(root, "disk.raw") {
 		t.Fatal("empty directory reported as a complete install")
 	}
 	for _, name := range []string{
@@ -120,7 +120,16 @@ func TestCompleteInstallDetection(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if !completeInstallExists(root) {
+	if !completeInstallExists(root, "disk.raw") {
 		t.Fatal("complete installation was not detected")
+	}
+	if completeInstallExists(root, "disk.qcow2") {
+		t.Fatal("raw installation was reported as a portable installation")
+	}
+	if err := os.WriteFile(filepath.Join(root, "vm", "disk.qcow2"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !completeInstallExists(root, "disk.qcow2") {
+		t.Fatal("complete portable installation was not detected")
 	}
 }

--- a/docs/PORTABLE_USB.md
+++ b/docs/PORTABLE_USB.md
@@ -1,0 +1,66 @@
+# Offline portable mode
+
+Portable mode runs the Windows launcher and a persistent Omarchy guest from
+removable storage without downloading anything on the target PC. It is an
+experimental launcher mode; preparation and redistribution tooling are outside
+this core change.
+
+## Host requirements
+
+- 64-bit Windows 11
+- Intel VT-x or AMD-V/SVM enabled in firmware
+- Windows Hypervisor Platform (the launcher can enable it with UAC and one
+  restart)
+- 8 GB RAM minimum; 16 GB recommended
+- exFAT or NTFS removable storage; USB 3 or faster recommended
+
+FAT32 is unsuitable because the decompressed factory image exceeds its 4 GB
+single-file limit. A 32 GB or 64 GB drive leaves useful room for persistent
+guest changes.
+
+## Layout
+
+The executable is started with `-portable` and expects this sibling layout:
+
+```text
+TryOmarchy-Portable/
+|-- TryOmarchy.exe
+|-- payload/
+|   |-- SHA256SUMS
+|   |-- winq-emu-alpha10-portable.zip
+|   |-- build-spec.json
+|   |-- vmlinuz-linux
+|   |-- initramfs-linux.img
+|   `-- rootfs.ext4.zst
+`-- data/                         created on first run
+    |-- runtime/                  extracted WINQ-EMU
+    |-- guest/rootfs.ext4         verified factory guest
+    `-- vm/disk.qcow2             persistent changes
+```
+
+The payload files must come from the release identified by `defaultReleaseURL`.
+The local `SHA256SUMS` is authenticated against the independent digest embedded
+in the launcher; carrying a modified manifest beside modified payload files does
+not bypass verification. The compressed archive and decompressed rootfs are
+checked against their separate manifest entries.
+
+Small guest artifacts are copied through `.part` files, the rootfs and QCOW2
+disk are published atomically, and cancellation removes staging files without
+damaging a complete prior installation. Install receipts preserve the verified
+fast path on later launches.
+
+The QCOW2 backing path is relative, so Windows may assign a different drive
+letter on another PC. The Windows Hypervisor Platform restart marker stays in
+the host's local app-data directory rather than travelling with the USB.
+
+## Running and reset
+
+From Command Prompt in the portable folder:
+
+```bat
+TryOmarchy.exe -portable
+```
+
+Shut Omarchy down from its system menu and wait for the QEMU window to close
+before ejecting the drive. To reset only the writable guest state, start with
+`-portable -fresh`; the authenticated factory image and payload remain intact.


### PR DESCRIPTION
## Summary

This adds an experimental, self-contained offline USB mode for Try Omarchy on Windows.

- Adds the `-portable` launcher mode
- Runs entirely from `payload/` and `data/` folders beside the executable
- Makes no network requests in portable mode
- Uses a compact QCOW2 writable disk with a relative backing path
- Supports changing USB drive letters and moving between Windows hosts
- Keeps the Windows Hypervisor Platform restart marker on the host
- Does not commit guest images, QEMU binaries, or redistributable bundles
- Limits this PR to Windows portable support; Linux and packaging work are excluded

## Security and reliability

The implementation preserves the current safeguards from `master`:

- Independently pinned `SHA256SUMS` trust root
- Separate verification of `rootfs.ext4.zst` and decompressed `rootfs.ext4`
- Cancellation-aware copying and decompression
- Manifest-bound installation receipts
- Atomic publication of artifacts, rootfs, and QCOW2 disks
- Quarantine of incomplete disk files
- No network fallback in portable mode

## Validation

Completed on the current rebased branch:

- Native Go tests pass
- Race-enabled tests pass
- Native and Windows vet pass
- Windows amd64 GUI build succeeds
- QCOW2 metadata and backing-chain tests pass
- Successfully booted an earlier rebased portable launcher to the Omarchy desktop on Windows 11
- Successfully shut down through the Omarchy system menu
- Verified writable persistence across launches

## Still to verify

- One final Windows hardware boot using the newly pinned v0.0.8-preview payload and latest rebased launcher
- Final licensing and corresponding-source review before anyone distributes a complete binary bundle