### PR TITLE
fix(setup): preflight required disk space

### DIFF
--- a/app/disk_space.go
+++ b/app/disk_space.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const (
+	diskSpaceReserve      int64 = 1 << 30
+	maxGuestManifestBytes       = 1 << 20
+	maxGuestArtifactBytes int64 = 1 << 40
+)
+
+var errInsufficientDiskSpace = errors.New("not enough free disk space")
+
+var (
+	diskFreeBytes      = platformDiskFreeBytes
+	allocatedFileBytes = platformAllocatedFileBytes
+)
+
+type guestArtifactSizes struct {
+	SchemaVersion int `json:"schemaVersion"`
+	Artifacts     []struct {
+		Bytes  int64  `json:"bytes"`
+		Path   string `json:"path"`
+		SHA256 string `json:"sha256"`
+	} `json:"artifacts"`
+}
+
+func readGuestArtifactSizes(path string, sums map[string]string) (map[string]int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, maxGuestManifestBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxGuestManifestBytes {
+		return nil, fmt.Errorf("guest artifact manifest is too large")
+	}
+	var manifest guestArtifactSizes
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("parsing guest artifact manifest: %w", err)
+	}
+	if manifest.SchemaVersion != 1 {
+		return nil, fmt.Errorf("unsupported guest artifact manifest schema %d", manifest.SchemaVersion)
+	}
+	sizes := make(map[string]int64, len(manifest.Artifacts))
+	for _, artifact := range manifest.Artifacts {
+		if filepath.Base(artifact.Path) != artifact.Path || artifact.Path == "." {
+			return nil, fmt.Errorf("invalid guest artifact path %q", artifact.Path)
+		}
+		if artifact.Bytes <= 0 || artifact.Bytes > maxGuestArtifactBytes {
+			return nil, fmt.Errorf("invalid size for guest artifact %s", artifact.Path)
+		}
+		if _, exists := sizes[artifact.Path]; exists {
+			return nil, fmt.Errorf("duplicate guest artifact %s", artifact.Path)
+		}
+		if !validSHA256(artifact.SHA256) || normalizedSHA256(artifact.SHA256) != normalizedSHA256(sums[artifact.Path]) {
+			return nil, fmt.Errorf("guest artifact metadata does not match authenticated SHA256SUMS for %s", artifact.Path)
+		}
+		sizes[artifact.Path] = artifact.Bytes
+	}
+	for _, name := range []string{"rootfs.ext4", "rootfs.ext4.zst"} {
+		if sizes[name] == 0 {
+			return nil, fmt.Errorf("guest artifact manifest has no size for %s", name)
+		}
+	}
+	return sizes, nil
+}
+
+func remainingFileBytes(path string, total int64) int64 {
+	var existing int64
+	for _, candidate := range []string{path, path + ".part"} {
+		info, err := os.Lstat(candidate)
+		if err == nil && info.Mode().IsRegular() && info.Size() > existing {
+			existing = info.Size()
+		}
+	}
+	if existing >= total {
+		return 0
+	}
+	return total - existing
+}
+
+func guestInstallSpaceRequired(archiveRemaining, rootfsAllocatedBytes int64) (int64, error) {
+	if archiveRemaining < 0 || rootfsAllocatedBytes <= 0 ||
+		archiveRemaining > (1<<63-1)-rootfsAllocatedBytes-diskSpaceReserve {
+		return 0, fmt.Errorf("guest artifact sizes overflow")
+	}
+	return archiveRemaining + rootfsAllocatedBytes + diskSpaceReserve, nil
+}
+
+// estimatedSparseRootfsBytes budgets for the zero blocks decompress omits.
+// The current 6.00 GiB image measures 3.87 GiB allocated; two thirds leaves
+// some headroom, with diskSpaceReserve covering normal release-to-release drift.
+func estimatedSparseRootfsBytes(logicalBytes int64) (int64, error) {
+	if logicalBytes <= 0 || logicalBytes > maxGuestArtifactBytes {
+		return 0, fmt.Errorf("invalid logical rootfs size")
+	}
+	return logicalBytes - logicalBytes/3, nil
+}
+
+func requireDiskSpace(path string, required int64) error {
+	if required <= 0 {
+		return nil
+	}
+	available, err := diskFreeBytes(path)
+	if err != nil {
+		return fmt.Errorf("checking free disk space: %w", err)
+	}
+	if available < required {
+		return fmt.Errorf("%w in %s: need %s available, have %s",
+			errInsufficientDiskSpace, filepath.Clean(path), formatGiB(required), formatGiB(available))
+	}
+	return nil
+}
+
+func formatGiB(bytes int64) string {
+	return fmt.Sprintf("%.1f GiB", float64(bytes)/float64(int64(1)<<30))
+}

--- a/app/disk_space_nonwindows.go
+++ b/app/disk_space_nonwindows.go
@@ -1,0 +1,53 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func existingDiskPath(path string) (string, error) {
+	path = filepath.Clean(path)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return "", fmt.Errorf("no existing parent for %s", path)
+		}
+		path = parent
+	}
+}
+
+func platformDiskFreeBytes(path string) (int64, error) {
+	existing, err := existingDiskPath(path)
+	if err != nil {
+		return 0, err
+	}
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(existing, &stat); err != nil {
+		return 0, err
+	}
+	available := uint64(stat.Bavail) * uint64(stat.Bsize)
+	if available > uint64(1<<63-1) {
+		return 1<<63 - 1, nil
+	}
+	return int64(available), nil
+}
+
+func platformAllocatedFileBytes(path string) (int64, error) {
+	var stat syscall.Stat_t
+	if err := syscall.Stat(path, &stat); err != nil {
+		return 0, err
+	}
+	if stat.Blocks < 0 || stat.Blocks > (1<<63-1)/512 {
+		return 0, fmt.Errorf("allocated file size is invalid")
+	}
+	return stat.Blocks * 512, nil
+}

--- a/app/disk_space_test.go
+++ b/app/disk_space_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func artifactSum(data string) string {
+	sum := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(sum[:])
+}
+
+func writeGuestSizeManifest(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "guest-manifest.json")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestReadGuestArtifactSizes(t *testing.T) {
+	rootSum := artifactSum("root")
+	archiveSum := artifactSum("archive")
+	path := writeGuestSizeManifest(t, `{"schemaVersion":1,"artifacts":[`+
+		`{"path":"rootfs.ext4","bytes":6442450944,"sha256":"`+rootSum+`"},`+
+		`{"path":"rootfs.ext4.zst","bytes":1445337714,"sha256":"`+archiveSum+`"}]}`)
+	sizes, err := readGuestArtifactSizes(path, map[string]string{
+		"rootfs.ext4": rootSum, "rootfs.ext4.zst": archiveSum,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sizes["rootfs.ext4"] != 6442450944 || sizes["rootfs.ext4.zst"] != 1445337714 {
+		t.Fatalf("sizes = %#v", sizes)
+	}
+}
+
+func TestReadGuestArtifactSizesRejectsUnauthenticatedMetadata(t *testing.T) {
+	rootSum := artifactSum("root")
+	archiveSum := artifactSum("archive")
+	path := writeGuestSizeManifest(t, `{"schemaVersion":1,"artifacts":[`+
+		`{"path":"rootfs.ext4","bytes":6442450944,"sha256":"`+rootSum+`"},`+
+		`{"path":"rootfs.ext4.zst","bytes":1445337714,"sha256":"`+archiveSum+`"}]}`)
+	_, err := readGuestArtifactSizes(path, map[string]string{
+		"rootfs.ext4": artifactSum("different"), "rootfs.ext4.zst": archiveSum,
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("error = %v, want authenticated-metadata failure", err)
+	}
+}
+
+func TestReadGuestArtifactSizesRejectsDuplicate(t *testing.T) {
+	rootSum := artifactSum("root")
+	archiveSum := artifactSum("archive")
+	path := writeGuestSizeManifest(t, `{"schemaVersion":1,"artifacts":[`+
+		`{"path":"rootfs.ext4","bytes":1,"sha256":"`+rootSum+`"},`+
+		`{"path":"rootfs.ext4","bytes":2,"sha256":"`+rootSum+`"},`+
+		`{"path":"rootfs.ext4.zst","bytes":1,"sha256":"`+archiveSum+`"}]}`)
+	_, err := readGuestArtifactSizes(path, map[string]string{
+		"rootfs.ext4": rootSum, "rootfs.ext4.zst": archiveSum,
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("error = %v, want duplicate failure", err)
+	}
+}
+
+func TestGuestInstallSpaceRequiredIncludesResumeAndReserve(t *testing.T) {
+	required, err := guestInstallSpaceRequired(512<<20, 4<<30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int64(512<<20) + (int64(4) << 30) + diskSpaceReserve; required != want {
+		t.Fatalf("required = %d, want %d", required, want)
+	}
+}
+
+func TestEstimatedSparseRootfsBytesUsesConservativeMeasuredRatio(t *testing.T) {
+	got, err := estimatedSparseRootfsBytes(6 << 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int64(4) << 30; got != want {
+		t.Fatalf("estimated sparse rootfs = %d, want %d", got, want)
+	}
+}
+
+func TestSparseEstimateAllowsMeasuredSevenGiBInstall(t *testing.T) {
+	rootfsAllocated, err := estimatedSparseRootfsBytes(6 << 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	required, err := guestInstallSpaceRequired(1445169669, rootfsAllocated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if required >= 7<<30 {
+		t.Fatalf("required = %d, want less than 7 GiB", required)
+	}
+}
+
+func TestEstimatedSparseRootfsBytesRejectsInvalidSize(t *testing.T) {
+	if _, err := estimatedSparseRootfsBytes(0); err == nil {
+		t.Fatal("zero logical rootfs size was accepted")
+	}
+}
+
+func TestRemainingFileBytesUsesLargestStagedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "payload")
+	if err := os.WriteFile(path, make([]byte, 3), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path+".part", make([]byte, 7), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := remainingFileBytes(path, 10); got != 3 {
+		t.Fatalf("remaining = %d, want 3", got)
+	}
+}
+
+func TestRequireDiskSpaceReportsRequiredAndAvailable(t *testing.T) {
+	original := diskFreeBytes
+	diskFreeBytes = func(string) (int64, error) { return 2 << 30, nil }
+	t.Cleanup(func() { diskFreeBytes = original })
+	err := requireDiskSpace(t.TempDir(), 3<<30)
+	if err == nil || !strings.Contains(err.Error(), "need 3.0 GiB") || !strings.Contains(err.Error(), "have 2.0 GiB") {
+		t.Fatalf("error = %v", err)
+	}
+	if !errors.Is(err, errInsufficientDiskSpace) {
+		t.Fatalf("error = %v, want insufficient-disk-space sentinel", err)
+	}
+}
+
+func TestRequireDiskSpacePropagatesProbeFailure(t *testing.T) {
+	original := diskFreeBytes
+	want := errors.New("probe failed")
+	diskFreeBytes = func(string) (int64, error) { return 0, want }
+	t.Cleanup(func() { diskFreeBytes = original })
+	if err := requireDiskSpace(t.TempDir(), 1); !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+}

--- a/app/disk_space_windows.go
+++ b/app/disk_space_windows.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	procGetDiskFreeSpaceExW    = syscall.NewLazyDLL("kernel32.dll").NewProc("GetDiskFreeSpaceExW")
+	procGetCompressedFileSizeW = syscall.NewLazyDLL("kernel32.dll").NewProc("GetCompressedFileSizeW")
+	procSetLastError           = syscall.NewLazyDLL("kernel32.dll").NewProc("SetLastError")
+)
+
+func existingDiskPath(path string) (string, error) {
+	path = filepath.Clean(path)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return "", fmt.Errorf("no existing parent for %s", path)
+		}
+		path = parent
+	}
+}
+
+func platformDiskFreeBytes(path string) (int64, error) {
+	existing, err := existingDiskPath(path)
+	if err != nil {
+		return 0, err
+	}
+	ptr, err := syscall.UTF16PtrFromString(existing)
+	if err != nil {
+		return 0, err
+	}
+	var available uint64
+	r1, _, callErr := procGetDiskFreeSpaceExW.Call(uintptr(unsafe.Pointer(ptr)), uintptr(unsafe.Pointer(&available)), 0, 0)
+	if r1 == 0 {
+		return 0, callErr
+	}
+	if available > uint64(1<<63-1) {
+		return 1<<63 - 1, nil
+	}
+	return int64(available), nil
+}
+
+func platformAllocatedFileBytes(path string) (int64, error) {
+	ptr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	var high uint32
+	procSetLastError.Call(0)
+	low, _, callErr := procGetCompressedFileSizeW.Call(uintptr(unsafe.Pointer(ptr)), uintptr(unsafe.Pointer(&high)))
+	if uint32(low) == 0xffffffff && callErr != syscall.Errno(0) {
+		return 0, callErr
+	}
+	allocated := uint64(high)<<32 | uint64(uint32(low))
+	if allocated > uint64(1<<63-1) {
+		return 0, fmt.Errorf("allocated file size is too large")
+	}
+	return int64(allocated), nil
+}

--- a/app/download_test.go
+++ b/app/download_test.go
@@ -296,9 +296,10 @@ func TestDownloadVerifiedCancelsActiveRequest(t *testing.T) {
 }
 
 type blockingDownloadBody struct {
-	started chan struct{}
-	closed  chan struct{}
-	once    sync.Once
+	started   chan struct{}
+	closed    chan struct{}
+	once      sync.Once
+	closeOnce sync.Once
 }
 
 func (b *blockingDownloadBody) Read([]byte) (int, error) {
@@ -309,12 +310,23 @@ func (b *blockingDownloadBody) Read([]byte) (int, error) {
 
 func (b *blockingDownloadBody) Close() error {
 	b.once.Do(func() { close(b.started) })
-	select {
-	case <-b.closed:
-	default:
-		close(b.closed)
-	}
+	b.closeOnce.Do(func() { close(b.closed) })
 	return nil
+}
+
+func TestBlockingDownloadBodyCloseIsConcurrentSafe(t *testing.T) {
+	body := &blockingDownloadBody{started: make(chan struct{}), closed: make(chan struct{})}
+	var wait sync.WaitGroup
+	for range 16 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			if err := body.Close(); err != nil {
+				t.Errorf("Close: %v", err)
+			}
+		}()
+	}
+	wait.Wait()
 }
 
 func TestDownloadVerifiedCancelsBlockedBodyAndCleansPartial(t *testing.T) {

--- a/app/fetch.go
+++ b/app/fetch.go
@@ -20,7 +20,7 @@ import (
 // the authenticated SHA256SUMS, and decompresses the rootfs.
 
 var (
-	downloadedGuestArtifacts = []string{"build-spec.json", "vmlinuz-linux", "initramfs-linux.img"}
+	downloadedGuestArtifacts = []string{"guest-manifest.json", "build-spec.json", "vmlinuz-linux", "initramfs-linux.img"}
 	installedGuestArtifacts  = []string{"build-spec.json", "vmlinuz-linux", "initramfs-linux.img", "rootfs.ext4"}
 )
 
@@ -90,7 +90,7 @@ func ensureGuestFiles(cfg *config, release, sumsSHA256 string) error {
 	if err != nil {
 		return fmt.Errorf("authenticating SHA256SUMS: %w", err)
 	}
-	for _, name := range []string{"build-spec.json", "vmlinuz-linux", "initramfs-linux.img", "rootfs.ext4", "rootfs.ext4.zst"} {
+	for _, name := range []string{"guest-manifest.json", "build-spec.json", "vmlinuz-linux", "initramfs-linux.img", "rootfs.ext4", "rootfs.ext4.zst"} {
 		if !validSHA256(sums[name]) {
 			return fmt.Errorf("release manifest has no valid SHA256 for %s", name)
 		}
@@ -106,6 +106,10 @@ func ensureGuestFiles(cfg *config, release, sumsSHA256 string) error {
 			return fmt.Errorf("preparing %s: %w", name, err)
 		}
 	}
+	artifactSizes, err := readGuestArtifactSizes(filepath.Join(cfg.guestDir, "guest-manifest.json"), sums)
+	if err != nil {
+		return fmt.Errorf("reading authenticated guest artifact sizes: %w", err)
+	}
 
 	zst := filepath.Join(cfg.guestDir, "rootfs.ext4.zst")
 	rootfs := filepath.Join(cfg.guestDir, "rootfs.ext4")
@@ -120,10 +124,24 @@ func ensureGuestFiles(cfg *config, release, sumsSHA256 string) error {
 		if err := removeCachedFile(rootfs); err != nil {
 			return fmt.Errorf("removing incomplete rootfs.ext4: %w", err)
 		}
+		rootfsAllocated, err := estimatedSparseRootfsBytes(artifactSizes["rootfs.ext4"])
+		if err != nil {
+			return err
+		}
+		required, err := guestInstallSpaceRequired(remainingFileBytes(zst, artifactSizes["rootfs.ext4.zst"]), rootfsAllocated)
+		if err != nil {
+			return err
+		}
+		if err := requireDiskSpace(cfg.guestDir, required); err != nil {
+			return fmt.Errorf("preflighting Omarchy storage: %w", err)
+		}
 		if err := ensureVerifiedDownload(client, normalizedRelease(release)+"/rootfs.ext4.zst", zst,
 			sums["rootfs.ext4.zst"], fmt.Sprintf("Downloading Omarchy (%d of %d)...",
 				len(downloadedGuestArtifacts)+1, len(downloadedGuestArtifacts)+1), ui); err != nil {
 			return fmt.Errorf("preparing rootfs.ext4.zst: %w", err)
+		}
+		if err := requireDiskSpace(cfg.guestDir, rootfsAllocated+diskSpaceReserve); err != nil {
+			return fmt.Errorf("preflighting Omarchy unpack: %w", err)
 		}
 		ui.setStatus("Unpacking the Omarchy system...")
 		if err := decompress(zst, rootfs, sums["rootfs.ext4"], ui); err != nil {

--- a/app/http_retry.go
+++ b/app/http_retry.go
@@ -50,7 +50,7 @@ func setupFailureHelp(err error) string {
 	}
 	// Setup writes several GB, and an image update needs room for the old and
 	// new copies at once. Retrying on connection advice never clears that.
-	if isDiskFull(err) {
+	if errors.Is(err, errInsufficientDiskSpace) || isDiskFull(err) {
 		return "Your PC is out of disk space. Free up a few gigabytes, then start Try Omarchy again."
 	}
 	return "Check your connection and start Try Omarchy again."

--- a/app/http_retry_test.go
+++ b/app/http_retry_test.go
@@ -54,6 +54,17 @@ func TestSetupFailureHelpExplainsDiskFull(t *testing.T) {
 	}
 }
 
+func TestSetupFailureHelpExplainsPreflightDiskFull(t *testing.T) {
+	err := fmt.Errorf("preflighting Omarchy storage: %w", errInsufficientDiskSpace)
+	got := setupFailureHelp(err)
+	if got == "Check your connection and start Try Omarchy again." {
+		t.Fatalf("preflight disk-full error got connection help: %q", got)
+	}
+	if !strings.Contains(got, "disk space") {
+		t.Fatalf("preflight disk-full help does not mention disk space: %q", got)
+	}
+}
+
 func TestGetWithSetupRetryStopsAfterBound(t *testing.T) {
 	configureSetupCancellation(false)
 	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {

--- a/app/manifest_test.go
+++ b/app/manifest_test.go
@@ -20,6 +20,7 @@ func TestDefaultReleaseManifestPin(t *testing.T) {
 	}
 	for _, name := range []string{
 		"build-spec.json",
+		"guest-manifest.json",
 		"initramfs-linux.img",
 		"rootfs.ext4",
 		"rootfs.ext4.zst",

--- a/app/qemu.go
+++ b/app/qemu.go
@@ -138,6 +138,16 @@ func prepareDisk(cfg *config, expandedMiB int64) error {
 		return err
 	}
 	defer src.Close()
+	allocated, err := allocatedFileBytes(filepath.Join(cfg.guestDir, "rootfs.ext4"))
+	if err != nil {
+		return fmt.Errorf("measuring the factory disk: %w", err)
+	}
+	if allocated > (1<<63-1)-diskSpaceReserve {
+		return fmt.Errorf("factory disk allocation is too large")
+	}
+	if err := requireDiskSpace(cfg.vmDir, allocated+diskSpaceReserve); err != nil {
+		return fmt.Errorf("preflighting writable disk storage: %w", err)
+	}
 	dst, err := os.Create(tmp)
 	if err != nil {
 		return err

--- a/app/qemu_nonwindows_test.go
+++ b/app/qemu_nonwindows_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -65,6 +66,38 @@ func TestPrepareDiskPublishesCompleteFile(t *testing.T) {
 	}
 	if _, err := os.Stat(cfg.disk + ".part"); !os.IsNotExist(err) {
 		t.Fatalf("staging file remains after commit: %v", err)
+	}
+}
+
+func TestPrepareDiskRejectsInsufficientAllocatedSpace(t *testing.T) {
+	dir := t.TempDir()
+	guestDir := filepath.Join(dir, "guest")
+	vmDir := filepath.Join(dir, "vm")
+	if err := os.MkdirAll(guestDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rootfs := filepath.Join(guestDir, "rootfs.ext4")
+	if err := os.WriteFile(rootfs, []byte("factory rootfs"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	originalFree := diskFreeBytes
+	originalAllocated := allocatedFileBytes
+	diskFreeBytes = func(string) (int64, error) { return 2 << 30, nil }
+	allocatedFileBytes = func(string) (int64, error) { return 2 << 30, nil }
+	t.Cleanup(func() {
+		diskFreeBytes = originalFree
+		allocatedFileBytes = originalAllocated
+	})
+	cfg := &config{guestDir: guestDir, vmDir: vmDir, disk: filepath.Join(vmDir, "disk.raw")}
+	err := prepareDisk(cfg, 4*1024)
+	if err == nil || !strings.Contains(err.Error(), "preflighting writable disk storage") {
+		t.Fatalf("error = %v, want disk-space failure", err)
+	}
+	if _, statErr := os.Stat(cfg.disk + ".part"); !os.IsNotExist(statErr) {
+		t.Fatalf("disk staging file exists after preflight: %v", statErr)
 	}
 }
 


### PR DESCRIPTION
Summary

Fail setup early when the target volume does not have enough free space, rather than after a large download, partial unpack, or writable-disk copy.

* Read artifact sizes from the authenticated guest-manifest.json.
* Cross-check artifact hashes against the authenticated SHA256SUMS.
* Check peak space before downloading the rootfs archive.
* Recheck available space immediately before unpacking.
* Account for retained .part data when resuming downloads.
* Measure allocated rather than logical bytes for the sparse factory disk.
* Report the required and available space clearly in GiB.

The checks run against the actual installation volume. During updates, the existing installation remains present when free space is measured, so peak replacement usage is included.

Dependency

Depends on #7.

This PR is intentionally stacked on the exact current #7 head (d635475). Once #7 merges unchanged, the remaining review diff is the single disk-space commit 4a19396.

Validation

Validated on this exact commit and tree:

* go test -race -cover ./... — passed with 66.5% statement coverage
* go vet ./... — passed
* GOOS=windows GOARCH=amd64 go vet -unsafeptr=false ./... — passed
* Windows GUI launcher build — passed
* Release-helper compilation and runtime-lock validation — passed
* Guest contract — passed
* Mechanical PR preflight — passed with no blockers or warnings

Tests cover authenticated size parsing, hash mismatch and duplicate rejection, resumed-byte accounting, required-space arithmetic, required/available diagnostics, probe failures, and insufficient space before writable-disk staging.

Compatibility

No CLI or configuration changes. Existing installations, resumable downloads, and update rollback behaviour are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added disk-space preflight checks before downloading guest artifacts, unpacking files, and creating writable VM storage.
  * Downloads now include authenticated guest artifact metadata and support safer resumable transfers.
  * Added platform-specific disk-space and allocated-storage detection for Windows and non-Windows systems.

* **Bug Fixes**
  * Improved handling of interrupted, partial, mismatched, or stalled downloads.
  * Error guidance now clearly identifies insufficient disk space and suggests appropriate action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->