### PR TITLE
Refresh guest package lock for nautilus 50.3 and fd 10.5

### DIFF
--- a/guest-build/0008-Refresh-guest-package-lock-for-nautilus-50.3-and-fd-.patch
+++ b/guest-build/0008-Refresh-guest-package-lock-for-nautilus-50.3-and-fd-.patch
@@ -1,0 +1,43 @@
+From 2d048dc5dea78b93367d01499f818ca245aa4161 Mon Sep 17 00:00:00 2001
+From: Try Omarchy Release <actions@users.noreply.github.com>
+Date: Sun, 30 Aug 2026 19:10:26 -0400
+Subject: [PATCH] Refresh guest package lock for nautilus 50.3 and fd 10.5
+
+---
+ guest/packages.lock.json | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/guest/packages.lock.json b/guest/packages.lock.json
+index 603bab6..6d2f325 100644
+--- a/guest/packages.lock.json
++++ b/guest/packages.lock.json
+@@ -61,7 +61,7 @@
+     "eza": "0.23.5-2",
+     "fastfetch": "2.67.1-1",
+     "fcft": "3.3.3-1",
+-    "fd": "10.4.2-2",
++    "fd": "10.5.0-1",
+     "ffmpeg": "2:9.0.1-4",
+     "fftw": "3.3.11-1",
+     "file": "5.48-1",
+@@ -267,7 +267,7 @@
+     "libmnl": "1.0.5-2",
+     "libmodplug": "0.8.9.0-7",
+     "libmysofa": "1.3.5-1",
+-    "libnautilus-extension": "50.2.2-1",
++    "libnautilus-extension": "50.3-1",
+     "libndp": "1.9-1",
+     "libnetfilter_conntrack": "1.1.1-1",
+     "libnewt": "0.52.25-2",
+@@ -414,7 +414,7 @@
+     "mtdev": "1.1.7-1",
+     "mujs": "1.3.9-1",
+     "muparser": "2.3.5-2",
+-    "nautilus": "50.2.2-1",
++    "nautilus": "50.3-1",
+     "ncurses": "6.6-2",
+     "neovim": "0.12.5-1",
+     "nettle": "4.0-1",
+-- 
+2.55.0
+


### PR DESCRIPTION
The v0.0.8-preview guest build failed on lock drift, which is the expected behaviour when Arch moves. Refreshed the lock and reviewed the diff.

Three packages moved, nothing added or removed:

- fd 10.4.2-2 to 10.5.0-1
- libnautilus-extension 50.2.2-1 to 50.3-1
- nautilus 50.2.2-1 to 50.3-1

Minor bumps, and the two nautilus packages move together as expected.

Verified with `scripts/release/build-guest.sh --contract-only`: the full patch series applies and the guest contract tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled guest packages, including Nautilus and its extension, to newer versions.
  * Updated the `fd` package to version 10.5.0-1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->