### PR TITLE
Add v0.0.8-preview release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,21 @@
 
 ## Unreleased
 
+## v0.0.8-preview - 2026-08-30
+
+- Fixed the launcher quitting on its own after about half an hour. Omarchy kept running, but the Windows key and every Windows shortcut went back to Windows, and the window could no longer be closed normally.
+- Fixed setup blaming your connection when the real problem was a full disk.
+- Removed a stall of about a minute when the bundled runtime rolled back to its previous version.
+- Added resumable downloads so an interrupted setup continues where it stopped instead of fetching the payload again, with bounded retries when antivirus or indexing briefly locks a finished file.
+- Added version details to the launcher, so Explorer, Task Manager and the Windows permission prompt now show Try Omarchy instead of a blank entry.
 - Added a source-locked CI build for the patched Windows QEMU runtime, including matching source, licenses, package inventory, provenance, and per-file hashes.
 - Added isolated signed test launchers so runtime candidates can be exercised without changing the production payload.
 - Hardened runtime packaging and validated clean setup, CPU fallback, scoped Windows-key handling, clipboard sharing, shutdown, relaunch, and persistent guest data in a nested Windows VM.
 - Made text clipboard sharing survive late guest startup, Wayland reconnects, early Windows copies, and temporary Windows clipboard contention.
+- Updated the guest image to nautilus 50.3 and fd 10.5.
+- Known limitation: Win+L still locks Windows instead of reaching Omarchy. Windows reserves that shortcut and no application can intercept it, so rebind the Omarchy action if you need it.
+
+Thanks to [Tom Ballard](https://github.com/tcballard) for resumable downloads in [PR #7](https://github.com/tsouth89/try-omarchy-windows/pull/7), and to everyone who reported Windows shortcuts leaking through while Omarchy was running.
 
 ## v0.0.7-preview - 2026-08-30
 


### PR DESCRIPTION
Release notes for v0.0.8-preview. Moves the Unreleased entries into the new section and adds the launcher and guest changes from this cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog notes for launcher stability improvements.
  * Documented improved disk-space error handling and resumable downloads.
  * Documented fixes for runtime rollback stalls and clipboard reliability.
  * Added notes on launcher version metadata, runtime validation, guest image updates, and the remaining Win+L limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->