### PR TITLE
Explain that ARM64 Windows is unsupported instead of blaming the BIOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Stopped setup on ARM64 Windows PCs with a clear explanation instead of failing through a WHP feature enable, a reboot, and impossible BIOS advice. Try Omarchy remains x86_64-only.
 
 ## v0.0.8-preview - 2026-08-30
 

--- a/app/arch_windows.go
+++ b/app/arch_windows.go
@@ -1,0 +1,75 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"unsafe"
+)
+
+// IMAGE_FILE_MACHINE_* from winnt.h: what IsWow64Process2 reports for the
+// CPU Windows itself runs on, no matter which architecture the asking process
+// was built for.
+const (
+	imageFileMachineAmd64 = 0x8664
+	imageFileMachineArm64 = 0xaa64
+)
+
+var (
+	procGetCurrentProcess = kernel32.NewProc("GetCurrentProcess")
+	procIsWow64Process2   = kernel32.NewProc("IsWow64Process2")
+)
+
+// nativeMachine returns the IMAGE_FILE_MACHINE_* of the CPU Windows itself is
+// running on, or 0 when the answer is unavailable (the API shipped in
+// Windows 10 1607; on anything older an x64 process sits on x64 hardware).
+// The OS is asked instead of trusting runtime.GOARCH because the launcher
+// ships as amd64 and Windows happily runs it on ARM64 PCs under emulation,
+// where GOARCH still says amd64 while the native hypervisor DLLs can't load.
+func nativeMachine() uint16 {
+	if procIsWow64Process2.Find() != nil {
+		return 0
+	}
+	handle, _, _ := procGetCurrentProcess.Call()
+	var processMachine, native uint16
+	if r, _, _ := procIsWow64Process2.Call(handle,
+		uintptr(unsafe.Pointer(&processMachine)), uintptr(unsafe.Pointer(&native))); r == 0 {
+		return 0
+	}
+	return native
+}
+
+// hostArchUnsupportedReason returns "" when this machine can run Try Omarchy,
+// otherwise the message to show the user. The launcher, the WINQ-EMU runtime
+// and the guest image are all x86_64-only, so ARM64 Windows PCs cannot run
+// the app - and before this check they got the worst possible tour: an
+// emulated x64 process cannot load the native WinHvPlatform.dll, so WHPX
+// looked missing, setup helpfully enabled the WHP feature and rebooted, and
+// only then blamed firmware virtualization settings (VT-x/SVM) that ARM
+// firmware does not even have.
+func hostArchUnsupportedReason() string {
+	if runtime.GOARCH != "amd64" {
+		// A future native ARM64 launcher would still ship the x86_64 guest
+		// and runtime today, so it gets the same message.
+		return intelAMDOnlyMessage("an ARM64 processor")
+	}
+	if nativeMachine() == imageFileMachineArm64 {
+		return intelAMDOnlyMessage("an ARM64 processor (this launcher is running under Windows' x64 emulation)")
+	}
+	return ""
+}
+
+// intelAMDOnlyMessage is the honest version of the ARM64 story: nothing on
+// the machine is broken or misconfigured - the hardware line sits elsewhere.
+func intelAMDOnlyMessage(detail string) string {
+	return strings.Join([]string{
+		"Try Omarchy needs an Intel or AMD (x86_64) PC.",
+		"",
+		fmt.Sprintf("This PC has %s. Nothing is misconfigured: the x86_64 virtualization Try Omarchy is built on is not supported on ARM64 Windows, so setup cannot continue on this PC.", detail),
+		"",
+		"To try Omarchy, run it on an Intel or AMD Windows PC. There is no ARM64 build yet - if you would like one, please open an issue:",
+		"https://github.com/tsouth89/try-omarchy-windows/issues",
+	}, "\n")
+}

--- a/app/arch_windows_test.go
+++ b/app/arch_windows_test.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package main
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The machine the test runs on decides which branch applies: CI and real
+// user hardware are x64-on-x64 (must run), ARM64 Windows gets the stop
+// message. Either way, when a message is produced it must name the hardware
+// that works and where to ask for an ARM64 build.
+func TestHostArchUnsupportedReason(t *testing.T) {
+	reason := hostArchUnsupportedReason()
+	supported := runtime.GOARCH == "amd64" && nativeMachine() == imageFileMachineAmd64
+	if supported && reason != "" {
+		t.Fatalf("x64 launcher on x64 Windows should be supported, got: %q", reason)
+	}
+	if !supported && reason == "" && nativeMachine() != 0 {
+		t.Fatal("non-x64 machine got no explanation")
+	}
+	if reason == "" {
+		return
+	}
+	for _, want := range []string{"Intel", "AMD", "https://github.com/tsouth89/try-omarchy-windows"} {
+		if !strings.Contains(reason, want) {
+			t.Errorf("message should mention %q, got: %q", want, reason)
+		}
+	}
+}

--- a/app/setup.go
+++ b/app/setup.go
@@ -166,6 +166,14 @@ func restartWindows() {
 // ensureWHP walks the user through switching the hypervisor on. Returns only
 // when WHPX is usable; every other path explains itself and exits.
 func ensureWHP(cfg *config) {
+	// One gate before everything: an emulated x64 launcher on ARM64 Windows
+	// cannot even load WinHvPlatform.dll, so the WHPX check below reads as
+	// "virtualization disabled" and the machine gets taken through a feature
+	// enable, a reboot, and firmware advice (VT-x/SVM) that does not exist on
+	// ARM. Tell the truth instead and stop here.
+	if reason := hostArchUnsupportedReason(); reason != "" {
+		fatal("%s", reason)
+	}
 	if whpPresent() {
 		return
 	}

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -15,6 +15,7 @@ Try Omarchy runs the full x86_64 Arch Linux environment used by Omarchy. It is n
 ## Current limits
 
 - Windows 11 with hardware virtualization is required.
+- ARM64 Windows PCs (Snapdragon and similar) are not supported: the launcher, runtime, and guest image are all x86_64, and setup stops with an explanation instead of blaming virtualization settings.
 - GPU acceleration depends on the patched WINQ-EMU runtime and compatible Windows graphics drivers. Try Omarchy falls back to CPU rendering when that path is unavailable.
 - USB devices, host webcams, and arbitrary PCI devices are not passed through.
 - Networking uses QEMU NAT. Services inside the guest are not exposed to the Windows network automatically.


### PR DESCRIPTION
## Summary

On ARM64 Windows PCs (Snapdragon X Elite etc.), the launcher currently fails with:

> Windows' virtualization is switched on, but your PC's hardware virtualization looks disabled.
> Enable it in your PC's BIOS/UEFI settings (usually called Intel VT-x, AMD-V, or SVM)...

That message is unreachable advice on ARM firmware, and getting there costs the user a UAC prompt, a DISM feature enable, and a reboot. This PR stops ARM64 machines at startup with an honest explanation instead.

## What actually happens on ARM64 (measured on a Snapdragon X1E80100)

- The launcher ships as amd64 (`GOOS=windows GOARCH=amd64` in CI), so it runs under Windows' x64 emulation.
- An emulated x64 process cannot load the native `WinHvPlatform.dll` (`%1 is not a valid Win32 application`), so `whpPresent()` always returns false - the hypervisor check reports "virtualization disabled" no matter what the machine supports.
- The user is walked through the WHP feature enable and a reboot, after which the marker-time heuristic concludes firmware virtualization is off.
- Meanwhile the machine is fine: `WHvGetCapability(HypervisorPresent)` from a native ARM64 process answers present, and `vmcompute` is running. The hard blocker is simply that the runtime (`qemu-system-x86_64w.exe`) and the guest image are x86_64, and WHPX cannot virtualize across architectures.

A minimal repro I built calls `WHvGetCapability` in both architectures on the same machine: native ARM64 returns hr=0/present=1, the x64 build fails at DLL load. This also explains why `runtime.GOARCH` cannot be trusted for the check - it still says `amd64` under emulation - so the gate asks Windows via `IsWow64Process2` instead.

## Changes

- `app/arch_windows.go` (new): `nativeMachine()` (IsWow64Process2) + `hostArchUnsupportedReason()` producing the user-facing message.
- `app/setup.go`: one gate at the top of `ensureWHP`, before any WHPX probing, feature enabling, or rebooting.
- `app/arch_windows_test.go`: covers both directions (x64-on-x64 must run; anything else must produce a message naming Intel/AMD and the issue tracker).
- `docs/COMPATIBILITY.md` + changelog: state the x86_64-only requirement explicitly.

## Testing

- `go vet -unsafeptr=false ./...` clean, `go build` (the exact CI command) clean, full `go test ./...` suite passes - all with `GOOS=windows GOARCH=amd64`, run on the ARM64 machine, so the gate test exercised the real emulated-x64-on-ARM64 scenario.
- Behavior on supported x64 hardware is unchanged: the gate only fires when the OS reports an ARM64 machine (or a non-amd64 launcher build).

## Notes

If ARM64 support is ever wanted, it is a bigger lift than a launcher flag: it needs an ARM64 QEMU runtime and an ARM64 Omarchy guest image (WHPX on ARM64 Windows does work - verified above). The message in this PR points users to the issue tracker to ask for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Setup now detects ARM64 Windows PCs and stops with a clear explanation instead of attempting unsupported virtualization steps or suggesting unnecessary BIOS changes.
  * Unsupported ARM64 systems are directed to request an ARM64 build.

* **Documentation**
  * Added compatibility guidance clarifying that ARM64 Windows is not currently supported.
  * Updated the upcoming changes list with this limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->