### PR TITLE
Add first-run install location choice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,23 @@ jobs:
       - name: Validate current release pin
         run: scripts/release/validate-pin.py "$(sed -n 's/.*releases\/download\/\([^\"]*\).*/\1/p' app/manifest.go)"
 
+  windows-launcher:
+    name: Windows launcher
+    runs-on: windows-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: app/go.mod
+          cache-dependency-path: app/go.sum
+
+      - name: Test launcher on Windows
+        working-directory: app
+        run: go test ./...
+
   guest-contract:
     name: Guest contract
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- New standard installs now ask whether to use the default Local AppData folder or a different local drive or folder before downloading the runtime and guest image. Alternate locations are checked for write access and free space, remembered across launches, and carried into Start-menu and Desktop shortcuts.
+
+### Fixes
+- Updated active download, update, issue, clone, and module links after the repository moved to `omacom`. Signed update manifests and existing guest and runtime receipts remain compatible with the old release base, so the transfer does not force a payload refresh or strand older launchers.
+
 ## v0.0.11-preview - 2026-09-03
 
 ### Features
@@ -59,7 +67,7 @@ Thanks to [majilesh](https://github.com/majilesh) for portable USB mode, [Tom Ba
 - Updated the guest image to nautilus 50.3 and fd 10.5.
 - Known limitation: Win+L still locks Windows instead of reaching Omarchy. Windows reserves that shortcut and no application can intercept it, so rebind the Omarchy action if you need it.
 
-Thanks to [Tom Ballard](https://github.com/tcballard) for resumable downloads in [PR #7](https://github.com/tsouth89/try-omarchy-windows/pull/7), and to everyone who reported Windows shortcuts leaking through while Omarchy was running.
+Thanks to [Tom Ballard](https://github.com/tcballard) for resumable downloads in [PR #7](https://github.com/omacom/try-omarchy-windows/pull/7), and to everyone who reported Windows shortcuts leaking through while Omarchy was running.
 
 ## v0.0.7-preview - 2026-08-30
 
@@ -78,7 +86,7 @@ Thanks to everyone testing Try Omarchy on real hardware and over remote sessions
 - Added an app compatibility guide covering Arch packages, VS Code, and current VM limitations.
 - Added an optional instant trial account that skips the first-boot form and lands directly on the desktop.
 
-Thanks to [Marx-Bray](https://github.com/Marx-Bray) for suggesting the launcher shortcuts in [issue #1](https://github.com/tsouth89/try-omarchy-windows/issues/1), and to everyone testing Try Omarchy across different Windows setups.
+Thanks to [Marx-Bray](https://github.com/Marx-Bray) for suggesting the launcher shortcuts in [issue #1](https://github.com/omacom/try-omarchy-windows/issues/1), and to everyone testing Try Omarchy across different Windows setups.
 
 ## v0.0.5-preview - 2026-08-29
 
@@ -88,7 +96,7 @@ Thanks to [Marx-Bray](https://github.com/Marx-Bray) for suggesting the launcher 
 - Prevented QEMU from trapping the Windows cursor when Try Omarchy is used over RDP.
 - Documented essential keys, uninstalling, compatibility expectations, and common questions.
 
-Thanks to [Tom Ballard](https://github.com/tcballard) for the release-manifest hardening and incomplete-install recovery in [PR #2](https://github.com/tsouth89/try-omarchy-windows/pull/2), and to everyone who tested the early previews and reported rough edges.
+Thanks to [Tom Ballard](https://github.com/tcballard) for the release-manifest hardening and incomplete-install recovery in [PR #2](https://github.com/omacom/try-omarchy-windows/pull/2), and to everyone who tested the early previews and reported rough edges.
 
 ## v0.0.4-preview - 2026-08-29
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Try Omarchy for Windows
 
-Run the full [Omarchy](https://omarchy.org) desktop in a window on Windows 10 or 11. No VMware, no VirtualBox, no dual boot: QEMU on the Windows Hypervisor Platform (WHPX), a prebuilt Arch image with Omarchy baked in, and the desktop rendered on your actual GPU (virgl + Venus Vulkan via [WINQ-EMU](https://github.com/cmspam/winq-emu)) with CPU rendering as the automatic fallback. No partitions, no bootloader, no changes to your Windows install: everything lives in one folder, `%LOCALAPPDATA%\TryOmarchy`, and deleting that folder is the uninstall.
+Run the full [Omarchy](https://omarchy.org) desktop in a window on Windows 10 or 11. No VMware, no VirtualBox, no dual boot: QEMU on the Windows Hypervisor Platform (WHPX), a prebuilt Arch image with Omarchy baked in, and the desktop rendered on your actual GPU (virgl + Venus Vulkan via [WINQ-EMU](https://github.com/cmspam/winq-emu)) with CPU rendering as the automatic fallback. No partitions, no bootloader, no changes to your Windows install: everything lives in one folder chosen on first run, with `%LOCALAPPDATA%\TryOmarchy` as the default.
 
 Download, boot, Hyprland.
 
@@ -14,7 +14,7 @@ Download, boot, Hyprland.
 
 - **The full Omarchy 4.0.2 desktop on new or reset guests**: Hyprland, the bar, notifications, all 22 themes, the screensavers. On our mid-range Ryzen 5 test laptop the desktop is up about 6 seconds after launch, and every launch after setup goes straight there. No Linux login screens, no console text, branded window.
 - **GPU acceleration**: Hyprland renders on the host GPU via virgl, `vulkaninfo` shows Venus, smooth video and audio (verified on a Radeon iGPU laptop); `-cpu host` (AVX2 and all) via WINQ-EMU's patched WHPX.
-- **One app, zero prerequisites**: `TryOmarchy.exe` (~8 MB, no console window). First run sets the machine up itself: switches on Windows' Hypervisor Platform (one permission prompt, one restart), then downloads the GPU runtime and the image SHA256-verified and boots into Omarchy's setup form. Once setup is complete it keeps a stable launcher under `%LOCALAPPDATA%\TryOmarchy` and can add optional Start-menu and Desktop shortcuts. After that it supervises everything: GPU/CPU auto-detect, the known WHPX launch wedge, in-guest reboot relaunch, poweroff cleanup.
+- **One app, zero prerequisites**: `TryOmarchy.exe` (~8 MB, no console window). First run lets you keep the default Local AppData location or choose another local drive or folder, switches on Windows' Hypervisor Platform (one permission prompt, one restart), then downloads the SHA256-verified GPU runtime and image and boots into Omarchy's setup form. Once setup is complete it keeps a stable launcher in the chosen data folder and can add optional Start-menu and Desktop shortcuts. After that it supervises everything: GPU/CPU auto-detect, the known WHPX launch wedge, in-guest reboot relaunch, poweroff cleanup.
 - **Feels like an app, not a VM**: the window is branded "Try Omarchy", the Windows key acts as Super only while the window is focused (Start menu and Win+Shift+S keep working everywhere else), Ctrl+Alt+F goes fullscreen.
 - **Two-way text clipboard sharing** between Windows and Omarchy (own compositor-native bridge over wl-clipboard, no SPICE) and **folder sharing** over virtio-9p: standard installs offer to create `Omarchy Shared` in your Windows home, then pin it in Omarchy's Files sidebar and link it into the Linux home. The tray can open the Windows folder at any time. File clipboard and drag-and-drop are not supported yet; use the shared folder to move files.
 - First boot offers an instant trial account or Omarchy's normal personalized account setup, with SDDM autologin after either path. Instant mode keeps `omarchy` as both the local username and lock-screen password, shows that on the setup splash, and repeats it once on the first desktop. Sudo remains passwordless in this disposable local trial.
@@ -50,9 +50,9 @@ Proven boot recipe: `-accel whpx -machine q35 -cpu qemu64`, direct kernel boot (
 
 ## Try it
 
-Download [TryOmarchy.exe](https://github.com/tsouth89/try-omarchy-windows/releases/latest/download/TryOmarchy.exe) (~8 MB, [SHA256](https://github.com/tsouth89/try-omarchy-windows/releases/latest/download/TryOmarchy.exe.sha256)) and open it. First run sets the machine up by itself: Windows asks permission to switch on the Hypervisor Platform and restarts once, then the app pulls the GPU runtime (a portable [WINQ-EMU](https://github.com/cmspam/winq-emu) tree, ~84 MB) and the Omarchy image (~1.7 GB), everything SHA256-verified. Choose the instant trial account to go straight to the desktop, or use Omarchy's setup form to choose your own account. Every launch after goes straight to the desktop.
+Download [TryOmarchy.exe](https://github.com/omacom/try-omarchy-windows/releases/latest/download/TryOmarchy.exe) (~8 MB, [SHA256](https://github.com/omacom/try-omarchy-windows/releases/latest/download/TryOmarchy.exe.sha256)) and open it. First run asks where to store the virtual machine, graphics runtime, and downloads. Use the default Local AppData location or choose another local drive or folder. Windows then asks permission to switch on the Hypervisor Platform and restarts once, after which the app pulls the GPU runtime (a portable [WINQ-EMU](https://github.com/cmspam/winq-emu) tree, ~84 MB) and the Omarchy image (~1.7 GB), everything SHA256-verified. Choose the instant trial account to go straight to the desktop, or use Omarchy's setup form to choose your own account. Every launch after goes straight to the desktop.
 
-After the first successful setup, Try Omarchy offers optional Start-menu and Desktop shortcuts. Start-menu installs include a separate settings shortcut. They point to a stable copy of the signed launcher in `%LOCALAPPDATA%\TryOmarchy`, so the original download can be moved or deleted. Opening a newer downloaded release refreshes that stable copy.
+After the first successful setup, Try Omarchy offers optional Start-menu and Desktop shortcuts. Start-menu installs include a separate settings shortcut. They point to a stable copy of the signed launcher in the chosen data folder, so the original download can be moved or deleted. Opening a newer downloaded release refreshes that stable copy.
 
 While Omarchy is running, the Try Omarchy tray icon can reopen its window, open the active shared folder, open Settings, create a diagnostics bundle, or request a clean shutdown.
 
@@ -63,7 +63,7 @@ Already have WINQ-EMU at `C:\WINQ-EMU`, or stock QEMU from the old bootstrap? Th
 Prefer to build the app yourself? Any machine with Go, then run the exe on Windows:
 
 ```
-git clone https://github.com/tsouth89/try-omarchy-windows
+git clone https://github.com/omacom/try-omarchy-windows
 cd try-omarchy-windows/app
 GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "-H windowsgui -s -w" -o TryOmarchy.exe .
 ```
@@ -81,16 +81,27 @@ trusted manifest digest via `-sums-sha256`.
 
 ### Reporting a problem
 
-Run `TryOmarchy.exe -diagnostics`. It writes one zip under
-`%LOCALAPPDATA%\TryOmarchy\diagnostics` with the launcher and QEMU logs, the
+Run `TryOmarchy.exe -diagnostics`. It writes one zip under the chosen data
+folder's `diagnostics` directory with the launcher and QEMU logs, the
 guest's console output, redacted settings, install and update state, the guest
 manifest, and machine facts (Windows build, CPU, memory). It includes no disk
 images or home-folder files and redacts known account paths and SSH key data.
 Logs can still contain local details, so review the zip before attaching it.
 
+### Install location
+
+New standard installs ask for a data location before downloading anything. The
+default is `%LOCALAPPDATA%\TryOmarchy`. Choosing another local drive or folder
+creates a `TryOmarchy` folder there and keeps a small
+`%LOCALAPPDATA%\TryOmarchy\data-location.json` pointer so direct launches can
+find it. Network locations are not supported for the virtual disk. Existing
+installs stay where they are, and an explicit `-dir PATH` still wins for that
+launch. Portable mode continues to use the `data` and `payload` folders beside
+the executable.
+
 ### Settings
 
-`%LOCALAPPDATA%\TryOmarchy\settings.json` keeps the choices that survive a
+`settings.json` in the chosen data folder keeps the choices that survive a
 relaunch. Every row has a matching flag, and a flag given on the command line
 wins for that launch:
 
@@ -178,7 +189,7 @@ Yes, and that's the point. QEMU on WHPX is the best virtualization stack Windows
 
 ### Why is the download only ~8 MB?
 
-TryOmarchy.exe is just the launcher. On first run it fetches the GPU runtime (~84 MB) and the Omarchy image (~1.7 GB), SHA256-verifies both, and caches them in `%LOCALAPPDATA%\TryOmarchy`. After that, launches work offline.
+TryOmarchy.exe is just the launcher. On first run it fetches the GPU runtime (~84 MB) and the Omarchy image (~1.7 GB), SHA256-verifies both, and caches them in the data folder you chose. After that, launches work offline.
 
 ### Why not just use a live USB?
 
@@ -190,7 +201,7 @@ The local trial account is named `omarchy` and its lock-screen password is `omar
 
 ### How do I remove Try Omarchy?
 
-Delete `%LOCALAPPDATA%\TryOmarchy`. That removes the launcher, runtime, image, and your writable virtual disk. If you created Windows shortcuts, remove them from the Start menu or Desktop like any other shortcut. The original downloaded `TryOmarchy.exe` can be deleted separately.
+Delete the data folder you chose during setup. That removes the launcher, runtime, image, and writable virtual disk. If you used an alternate location, also delete `%LOCALAPPDATA%\TryOmarchy\data-location.json`. If you created Windows shortcuts, remove them from the Start menu or Desktop like any other shortcut. The original downloaded `TryOmarchy.exe` can be deleted separately.
 
 ### I have the full Hyper-V feature set installed. Will it conflict?
 

--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ New standard installs ask for a data location before downloading anything. The
 default is `%LOCALAPPDATA%\TryOmarchy`. Choosing another local drive or folder
 creates a `TryOmarchy` folder there and keeps a small
 `%LOCALAPPDATA%\TryOmarchy\data-location.json` pointer so direct launches can
-find it. Network locations are not supported for the virtual disk. Existing
+find it. Standard installs require an NTFS or ReFS local drive because the
+virtual disk uses sparse files. Network locations are not supported. Existing
 installs stay where they are, and an explicit `-dir PATH` still wins for that
-launch. Portable mode continues to use the `data` and `payload` folders beside
-the executable.
+launch. Portable mode continues to support exFAT through the `data` and
+`payload` folders beside the executable.
 
 ### Settings
 

--- a/app/arch_windows.go
+++ b/app/arch_windows.go
@@ -70,6 +70,6 @@ func intelAMDOnlyMessage(detail string) string {
 		fmt.Sprintf("This PC has %s. Nothing is misconfigured: the x86_64 virtualization Try Omarchy is built on is not supported on ARM64 Windows, so setup cannot continue on this PC.", detail),
 		"",
 		"To try Omarchy, run it on an Intel or AMD Windows PC. There is no ARM64 build yet - if you would like one, please open an issue:",
-		"https://github.com/tsouth89/try-omarchy-windows/issues",
+		"https://github.com/omacom/try-omarchy-windows/issues",
 	}, "\n")
 }

--- a/app/arch_windows_test.go
+++ b/app/arch_windows_test.go
@@ -24,7 +24,7 @@ func TestHostArchUnsupportedReason(t *testing.T) {
 	if reason == "" {
 		return
 	}
-	for _, want := range []string{"Intel", "AMD", "https://github.com/tsouth89/try-omarchy-windows"} {
+	for _, want := range []string{"Intel", "AMD", "https://github.com/omacom/try-omarchy-windows"} {
 		if !strings.Contains(reason, want) {
 			t.Errorf("message should mention %q, got: %q", want, reason)
 		}

--- a/app/data_location.go
+++ b/app/data_location.go
@@ -185,10 +185,16 @@ func dataDirectoryUnclaimed(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	ignored := map[string]bool{
+		dataLocationPointerName + ".part": true,
+		"diagnostics":                     true,
+		"portable-host":                   true,
+	}
 	for _, entry := range entries {
-		// A power loss between writing and renaming the location pointer must
-		// not make an otherwise new default directory look like an install.
-		if entry.Name() != dataLocationPointerName+".part" {
+		// Diagnostics can be requested before setup, and portable mode keeps
+		// host-only state here. Neither claims the standard install location.
+		// The staged pointer covers a power loss before its atomic rename.
+		if !ignored[entry.Name()] {
 			return false, nil
 		}
 	}

--- a/app/data_location.go
+++ b/app/data_location.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	dataLocationPointerVersion = 1
+	dataLocationPointerName    = "data-location.json"
+	maxDataLocationBytes       = 16 << 10
+)
+
+// Kept as a variable so isolated signed test builds can use their own data
+// directory without changing production behavior.
+var defaultDataDirectoryName = "TryOmarchy"
+
+type dataLocationPointer struct {
+	Version int    `json:"version"`
+	Path    string `json:"path"`
+}
+
+type dataLocationChooser func(defaultDir string) (selected string, proceed bool, err error)
+
+// resolveStandardDataDirectory keeps the startup precedence in one tested
+// place: an explicit -dir wins, then a remembered alternate location, then an
+// existing default install, and finally the first-run chooser.
+func resolveStandardDataDirectory(defaultDir, requested string, explicit, prompt bool, choose dataLocationChooser) (string, bool, error) {
+	if explicit {
+		return requested, true, nil
+	}
+	selected, found, err := loadDataLocationPointer(defaultDir)
+	if err != nil {
+		return "", false, err
+	}
+	if found {
+		return selected, true, nil
+	}
+	if !prompt {
+		return defaultDir, true, nil
+	}
+	unclaimed, err := dataDirectoryUnclaimed(defaultDir)
+	if err != nil {
+		return "", false, err
+	}
+	if !unclaimed {
+		return defaultDir, true, nil
+	}
+	if choose == nil {
+		return "", false, fmt.Errorf("data location chooser is unavailable")
+	}
+	selected, proceed, err := choose(defaultDir)
+	if err != nil || !proceed {
+		return selected, proceed, err
+	}
+	selected, err = validateDataLocationPath(selected)
+	if err != nil {
+		return "", false, err
+	}
+	if !pathsEqual(selected, defaultDir) {
+		if err := saveDataLocationPointer(defaultDir, selected); err != nil {
+			return "", false, err
+		}
+	}
+	return selected, true, nil
+}
+
+func dataLocationPointerPath(defaultDir string) string {
+	return filepath.Join(defaultDir, dataLocationPointerName)
+}
+
+// loadDataLocationPointer resolves the small bootstrap record kept in the
+// default Local AppData directory. The record is needed because the launcher
+// cannot discover an installation on another drive before it knows where to
+// look. Explicit -dir and portable launches bypass it in main.
+func loadDataLocationPointer(defaultDir string) (string, bool, error) {
+	path := dataLocationPointerPath(defaultDir)
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	if !info.Mode().IsRegular() {
+		return "", false, fmt.Errorf("%s is not a regular file", path)
+	}
+	if info.Size() > maxDataLocationBytes {
+		return "", false, fmt.Errorf("%s is too large", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false, err
+	}
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.DisallowUnknownFields()
+	var pointer dataLocationPointer
+	if err := dec.Decode(&pointer); err != nil {
+		return "", false, fmt.Errorf("%s: %v", path, err)
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return "", false, fmt.Errorf("%s: data contains trailing content", path)
+	}
+	if pointer.Version != dataLocationPointerVersion {
+		return "", false, fmt.Errorf("%s: version %d is not supported", path, pointer.Version)
+	}
+	selected, err := validateDataLocationPath(pointer.Path)
+	if err != nil {
+		return "", false, fmt.Errorf("%s: %v", path, err)
+	}
+	defaultPath, err := validateDataLocationPath(defaultDir)
+	if err != nil {
+		return "", false, err
+	}
+	if pathsEqual(selected, defaultPath) {
+		return "", false, fmt.Errorf("%s points back to the default data directory", path)
+	}
+	return selected, true, nil
+}
+
+func saveDataLocationPointer(defaultDir, selected string) error {
+	defaultPath, err := validateDataLocationPath(defaultDir)
+	if err != nil {
+		return err
+	}
+	selectedPath, err := validateDataLocationPath(selected)
+	if err != nil {
+		return err
+	}
+	if pathsEqual(defaultPath, selectedPath) {
+		return fmt.Errorf("alternate data directory matches the default data directory")
+	}
+	if err := os.MkdirAll(defaultPath, 0o755); err != nil {
+		return err
+	}
+	pointer := dataLocationPointer{Version: dataLocationPointerVersion, Path: selectedPath}
+	data, err := json.MarshalIndent(pointer, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := dataLocationPointerPath(defaultPath)
+	tmp := path + ".part"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+func validateDataLocationPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("data directory is empty")
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("data directory must be an absolute path")
+	}
+	return filepath.Clean(path), nil
+}
+
+func dataDirectoryForSelection(parent string) (string, error) {
+	parent, err := validateDataLocationPath(parent)
+	if err != nil {
+		return "", err
+	}
+	if strings.EqualFold(filepath.Base(parent), defaultDataDirectoryName) {
+		return parent, nil
+	}
+	return filepath.Join(parent, defaultDataDirectoryName), nil
+}
+
+func dataDirectoryUnclaimed(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
+}
+
+func ensureDataDirectoryWritable(path string) error {
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(path, ".tryomarchy-write-test-*")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	if err := f.Close(); err != nil {
+		os.Remove(name)
+		return err
+	}
+	if err := os.Remove(name); err != nil {
+		return err
+	}
+	return nil
+}

--- a/app/data_location.go
+++ b/app/data_location.go
@@ -201,6 +201,25 @@ func dataDirectoryUnclaimed(path string) (bool, error) {
 	return true, nil
 }
 
+func dataDirectoryEmpty(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
+}
+
+func standardDataDirectorySelectable(path string) (bool, error) {
+	unclaimed, err := dataDirectoryUnclaimed(path)
+	if err != nil || unclaimed {
+		return unclaimed, err
+	}
+	return completeInstallExists(path, "disk.raw"), nil
+}
+
 func ensureDataDirectoryWritable(path string) error {
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		return err

--- a/app/data_location.go
+++ b/app/data_location.go
@@ -185,7 +185,14 @@ func dataDirectoryUnclaimed(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return len(entries) == 0, nil
+	for _, entry := range entries {
+		// A power loss between writing and renaming the location pointer must
+		// not make an otherwise new default directory look like an install.
+		if entry.Name() != dataLocationPointerName+".part" {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func ensureDataDirectoryWritable(path string) error {

--- a/app/data_location_test.go
+++ b/app/data_location_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDataLocationPointerRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	defaultDir := filepath.Join(root, "local", defaultDataDirectoryName)
+	selected := filepath.Join(root, "other drive", defaultDataDirectoryName)
+	if err := saveDataLocationPointer(defaultDir, selected); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dataLocationPointerPath(defaultDir) + ".part"); !os.IsNotExist(err) {
+		t.Fatal("staging file left behind")
+	}
+	got, ok, err := loadDataLocationPointer(defaultDir)
+	if err != nil || !ok || got != filepath.Clean(selected) {
+		t.Fatalf("pointer = %q, %v, %v", got, ok, err)
+	}
+}
+
+func TestDataLocationPointerMissingIsDefault(t *testing.T) {
+	if got, ok, err := loadDataLocationPointer(filepath.Join(t.TempDir(), "missing")); err != nil || ok || got != "" {
+		t.Fatalf("missing pointer = %q, %v, %v", got, ok, err)
+	}
+}
+
+func TestResolveStandardDataDirectoryPrecedence(t *testing.T) {
+	root := t.TempDir()
+	defaultDir := filepath.Join(root, "default")
+	remembered := filepath.Join(root, "remembered")
+	explicit := filepath.Join(root, "explicit")
+	if err := saveDataLocationPointer(defaultDir, remembered); err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	chooser := func(string) (string, bool, error) {
+		called = true
+		return "", false, nil
+	}
+	if got, proceed, err := resolveStandardDataDirectory(defaultDir, explicit, true, true, chooser); err != nil || !proceed || got != explicit {
+		t.Fatalf("explicit directory = %q, %v, %v", got, proceed, err)
+	}
+	if called {
+		t.Fatal("explicit directory opened the chooser")
+	}
+	if got, proceed, err := resolveStandardDataDirectory(defaultDir, defaultDir, false, true, chooser); err != nil || !proceed || got != remembered {
+		t.Fatalf("remembered directory = %q, %v, %v", got, proceed, err)
+	}
+	if called {
+		t.Fatal("remembered directory opened the chooser")
+	}
+}
+
+func TestResolveStandardDataDirectoryKeepsExistingDefault(t *testing.T) {
+	defaultDir := filepath.Join(t.TempDir(), "default")
+	if err := os.MkdirAll(defaultDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(defaultDir, "partial-download"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	chooser := func(string) (string, bool, error) {
+		called = true
+		return "", false, nil
+	}
+	if got, proceed, err := resolveStandardDataDirectory(defaultDir, defaultDir, false, true, chooser); err != nil || !proceed || got != defaultDir {
+		t.Fatalf("existing default = %q, %v, %v", got, proceed, err)
+	}
+	if called {
+		t.Fatal("existing default opened the chooser")
+	}
+}
+
+func TestResolveStandardDataDirectoryPersistsFirstChoice(t *testing.T) {
+	root := t.TempDir()
+	defaultDir := filepath.Join(root, "default")
+	selected := filepath.Join(root, "selected")
+	chooser := func(gotDefault string) (string, bool, error) {
+		if gotDefault != defaultDir {
+			t.Fatalf("chooser default = %q, want %q", gotDefault, defaultDir)
+		}
+		return selected, true, nil
+	}
+	got, proceed, err := resolveStandardDataDirectory(defaultDir, defaultDir, false, true, chooser)
+	if err != nil || !proceed || got != selected {
+		t.Fatalf("first choice = %q, %v, %v", got, proceed, err)
+	}
+	remembered, found, err := loadDataLocationPointer(defaultDir)
+	if err != nil || !found || remembered != selected {
+		t.Fatalf("saved choice = %q, %v, %v", remembered, found, err)
+	}
+}
+
+func TestResolveStandardDataDirectoryHonorsCancel(t *testing.T) {
+	defaultDir := filepath.Join(t.TempDir(), "default")
+	chooser := func(string) (string, bool, error) { return "", false, nil }
+	if got, proceed, err := resolveStandardDataDirectory(defaultDir, defaultDir, false, true, chooser); err != nil || proceed || got != "" {
+		t.Fatalf("cancel = %q, %v, %v", got, proceed, err)
+	}
+	if _, err := os.Stat(dataLocationPointerPath(defaultDir)); !os.IsNotExist(err) {
+		t.Fatalf("cancel wrote a pointer: %v", err)
+	}
+}
+
+func TestDataLocationPointerRejectsDamage(t *testing.T) {
+	root := t.TempDir()
+	defaultDir := filepath.Join(root, "default")
+	if err := os.MkdirAll(defaultDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string]string{
+		"garbage":  "{not json",
+		"version":  fmt.Sprintf(`{"version":2,"path":%q}`, filepath.Join(root, "other")),
+		"relative": `{"version":1,"path":"relative"}`,
+		"unknown":  fmt.Sprintf(`{"version":1,"path":%q,"extra":true}`, filepath.Join(root, "other")),
+		"trailing": fmt.Sprintf(`{"version":1,"path":%q} true`, filepath.Join(root, "other")),
+		"default":  fmt.Sprintf(`{"version":1,"path":%q}`, defaultDir),
+		"oversize": strings.Repeat(" ", maxDataLocationBytes+1),
+	}
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := os.WriteFile(dataLocationPointerPath(defaultDir), []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := loadDataLocationPointer(defaultDir); err == nil {
+				t.Fatal("damaged pointer accepted")
+			}
+		})
+	}
+}
+
+func TestDataDirectoryForSelection(t *testing.T) {
+	root := t.TempDir()
+	want := filepath.Join(root, defaultDataDirectoryName)
+	if got, err := dataDirectoryForSelection(root); err != nil || got != want {
+		t.Fatalf("parent selection = %q, %v, want %q", got, err, want)
+	}
+	if got, err := dataDirectoryForSelection(want); err != nil || got != want {
+		t.Fatalf("named selection = %q, %v, want %q", got, err, want)
+	}
+}
+
+func TestDataDirectoryUnclaimed(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "data")
+	if empty, err := dataDirectoryUnclaimed(dir); err != nil || !empty {
+		t.Fatalf("missing directory = %v, %v", empty, err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if empty, err := dataDirectoryUnclaimed(dir); err != nil || !empty {
+		t.Fatalf("empty directory = %v, %v", empty, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "partial"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if empty, err := dataDirectoryUnclaimed(dir); err != nil || empty {
+		t.Fatalf("claimed directory = %v, %v", empty, err)
+	}
+}
+
+func TestEnsureDataDirectoryWritable(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "new", "data")
+	if err := ensureDataDirectoryWritable(dir); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("write check left files behind: %v, %v", entries, err)
+	}
+}

--- a/app/data_location_test.go
+++ b/app/data_location_test.go
@@ -180,6 +180,65 @@ func TestDataDirectoryUnclaimed(t *testing.T) {
 	}
 }
 
+func TestStandardDataDirectorySelectionRejectsForeignFiles(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), defaultDataDirectoryName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreign := filepath.Join(dir, "keep-me.txt")
+	if err := os.WriteFile(foreign, []byte("not owned by Try Omarchy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if selectable, err := standardDataDirectorySelectable(dir); err != nil || selectable {
+		t.Fatalf("foreign directory selectable = %v, %v", selectable, err)
+	}
+	if err := cleanupCancelledSetup(dir, filepath.Join(t.TempDir(), "TryOmarchy.exe"), false); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(foreign); err != nil || string(data) != "not owned by Try Omarchy" {
+		t.Fatalf("foreign file after conservative cleanup = %q, %v", data, err)
+	}
+}
+
+func TestStandardDataDirectorySelectionAcceptsCompleteInstall(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), defaultDataDirectoryName)
+	for _, name := range []string{
+		filepath.Join("guest", "build-spec.json"),
+		filepath.Join("guest", "rootfs.ext4"),
+		filepath.Join("vm", "disk.raw"),
+	} {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if selectable, err := standardDataDirectorySelectable(dir); err != nil || !selectable {
+		t.Fatalf("complete install selectable = %v, %v", selectable, err)
+	}
+}
+
+func TestDataDirectoryEmpty(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "data")
+	if empty, err := dataDirectoryEmpty(dir); err != nil || !empty {
+		t.Fatalf("missing directory empty = %v, %v", empty, err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if empty, err := dataDirectoryEmpty(dir); err != nil || !empty {
+		t.Fatalf("new directory empty = %v, %v", empty, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "existing"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if empty, err := dataDirectoryEmpty(dir); err != nil || empty {
+		t.Fatalf("populated directory empty = %v, %v", empty, err)
+	}
+}
+
 func TestEnsureDataDirectoryWritable(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "new", "data")
 	if err := ensureDataDirectoryWritable(dir); err != nil {

--- a/app/data_location_test.go
+++ b/app/data_location_test.go
@@ -164,6 +164,14 @@ func TestDataDirectoryUnclaimed(t *testing.T) {
 	if empty, err := dataDirectoryUnclaimed(dir); err != nil || !empty {
 		t.Fatalf("directory with staged pointer = %v, %v", empty, err)
 	}
+	for _, name := range []string{"diagnostics", "portable-host"} {
+		if err := os.MkdirAll(filepath.Join(dir, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if empty, err := dataDirectoryUnclaimed(dir); err != nil || !empty {
+		t.Fatalf("directory with support-only state = %v, %v", empty, err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, "partial"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/app/data_location_test.go
+++ b/app/data_location_test.go
@@ -158,6 +158,12 @@ func TestDataDirectoryUnclaimed(t *testing.T) {
 	if empty, err := dataDirectoryUnclaimed(dir); err != nil || !empty {
 		t.Fatalf("empty directory = %v, %v", empty, err)
 	}
+	if err := os.WriteFile(filepath.Join(dir, dataLocationPointerName+".part"), []byte("incomplete"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if empty, err := dataDirectoryUnclaimed(dir); err != nil || !empty {
+		t.Fatalf("directory with staged pointer = %v, %v", empty, err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, "partial"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/app/data_location_windows.go
+++ b/app/data_location_windows.go
@@ -1,0 +1,59 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// chooseFirstRunDataDirectory asks once, before any payload is downloaded.
+// The folder picker selects a drive or parent folder and the launcher keeps
+// its files together in a TryOmarchy child directory.
+func chooseFirstRunDataDirectory(defaultDir string) (string, bool, error) {
+	for {
+		answer := msgBox(
+			"Choose where Try Omarchy stores its virtual machine, graphics runtime, and downloads.\n\n"+
+				"Default location:\n"+defaultDir+"\n\n"+
+				"Choose Yes to select another local drive or folder. Choose No to use the default location.",
+			mbYesNoCancel|mbIconQuestion,
+		)
+		switch answer {
+		case idCancel:
+			return "", false, nil
+		case idNo:
+			return defaultDir, true, nil
+		case idYes:
+			parent, ok := browseForFolder(0, "Choose a local drive or parent folder. Try Omarchy will create a TryOmarchy folder inside it.")
+			if !ok {
+				continue
+			}
+			selected, err := dataDirectoryForSelection(parent)
+			if err != nil {
+				errorBox("Try Omarchy cannot use that location.\n\n" + err.Error())
+				continue
+			}
+			volume := filepath.VolumeName(selected)
+			if volume == "" || strings.HasPrefix(volume, `\\`) {
+				errorBox("Choose a folder on a local Windows drive. Network locations are not supported for the virtual disk.")
+				continue
+			}
+			if err := ensureDataDirectoryWritable(selected); err != nil {
+				errorBox("Try Omarchy cannot write to that location.\n\n" + err.Error())
+				continue
+			}
+			available, err := diskFreeBytes(selected)
+			if err != nil {
+				errorBox("Try Omarchy cannot check the free space at that location.\n\n" + err.Error())
+				continue
+			}
+			if msgBox(fmt.Sprintf("Store Try Omarchy here?\n\n%s\n\nAvailable space: %s", selected, formatGiB(available)), mbYesNo|mbIconQuestion) != idYes {
+				continue
+			}
+			return selected, true, nil
+		default:
+			return "", false, nil
+		}
+	}
+}

--- a/app/data_location_windows.go
+++ b/app/data_location_windows.go
@@ -6,7 +6,26 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"unsafe"
 )
+
+var procGetDriveTypeW = syscall.NewLazyDLL("kernel32.dll").NewProc("GetDriveTypeW")
+
+const driveRemote = 4
+
+func dataLocationIsLocal(path string) bool {
+	volume := filepath.VolumeName(path)
+	if volume == "" || strings.HasPrefix(volume, `\\`) {
+		return false
+	}
+	root, err := syscall.UTF16PtrFromString(volume + `\`)
+	if err != nil {
+		return false
+	}
+	driveType, _, _ := procGetDriveTypeW.Call(uintptr(unsafe.Pointer(root)))
+	return driveType != driveRemote
+}
 
 // chooseFirstRunDataDirectory asks once, before any payload is downloaded.
 // The folder picker selects a drive or parent folder and the launcher keeps
@@ -34,8 +53,7 @@ func chooseFirstRunDataDirectory(defaultDir string) (string, bool, error) {
 				errorBox("Try Omarchy cannot use that location.\n\n" + err.Error())
 				continue
 			}
-			volume := filepath.VolumeName(selected)
-			if volume == "" || strings.HasPrefix(volume, `\\`) {
+			if !dataLocationIsLocal(selected) {
 				errorBox("Choose a folder on a local Windows drive. Network locations are not supported for the virtual disk.")
 				continue
 			}

--- a/app/data_location_windows.go
+++ b/app/data_location_windows.go
@@ -12,7 +12,15 @@ import (
 
 var procGetDriveTypeW = syscall.NewLazyDLL("kernel32.dll").NewProc("GetDriveTypeW")
 
-const driveRemote = 4
+const (
+	driveRemovable = 2
+	driveFixed     = 3
+	driveRAMDisk   = 6
+)
+
+func supportedLocalDriveType(driveType uintptr) bool {
+	return driveType == driveRemovable || driveType == driveFixed || driveType == driveRAMDisk
+}
 
 func dataLocationIsLocal(path string) bool {
 	volume := filepath.VolumeName(path)
@@ -24,7 +32,7 @@ func dataLocationIsLocal(path string) bool {
 		return false
 	}
 	driveType, _, _ := procGetDriveTypeW.Call(uintptr(unsafe.Pointer(root)))
-	return driveType != driveRemote
+	return supportedLocalDriveType(driveType)
 }
 
 // chooseFirstRunDataDirectory asks once, before any payload is downloaded.

--- a/app/data_location_windows.go
+++ b/app/data_location_windows.go
@@ -130,6 +130,15 @@ func chooseFirstRunDataDirectory(defaultDir string) (string, bool, error) {
 				errorBox("Try Omarchy cannot use that location.\n\n" + err.Error())
 				continue
 			}
+			selectable, err := standardDataDirectorySelectable(selected)
+			if err != nil {
+				errorBox("Try Omarchy cannot inspect that location.\n\n" + err.Error())
+				continue
+			}
+			if !selectable {
+				errorBox("That TryOmarchy folder is not empty and is not a complete Try Omarchy installation. Choose another parent folder or an empty TryOmarchy folder.")
+				continue
+			}
 			if err := ensureDataDirectoryWritable(selected); err != nil {
 				errorBox("Try Omarchy cannot write to that location.\n\n" + err.Error())
 				continue

--- a/app/data_location_windows.go
+++ b/app/data_location_windows.go
@@ -10,29 +10,90 @@ import (
 	"unsafe"
 )
 
-var procGetDriveTypeW = syscall.NewLazyDLL("kernel32.dll").NewProc("GetDriveTypeW")
+var (
+	procGetDriveTypeW         = syscall.NewLazyDLL("kernel32.dll").NewProc("GetDriveTypeW")
+	procGetVolumePathNameW    = syscall.NewLazyDLL("kernel32.dll").NewProc("GetVolumePathNameW")
+	procGetVolumeInformationW = syscall.NewLazyDLL("kernel32.dll").NewProc("GetVolumeInformationW")
+)
 
 const (
-	driveRemovable = 2
-	driveFixed     = 3
-	driveRAMDisk   = 6
+	driveRemovable          = 2
+	driveFixed              = 3
+	driveRAMDisk            = 6
+	fileSupportsSparseFiles = 0x40
 )
 
 func supportedLocalDriveType(driveType uintptr) bool {
 	return driveType == driveRemovable || driveType == driveFixed || driveType == driveRAMDisk
 }
 
-func dataLocationIsLocal(path string) bool {
-	volume := filepath.VolumeName(path)
-	if volume == "" || strings.HasPrefix(volume, `\\`) {
-		return false
+func dataLocationVolumeRoot(path string) (string, error) {
+	if strings.HasPrefix(filepath.VolumeName(path), `\\`) {
+		return "", fmt.Errorf("network paths are not supported")
 	}
-	root, err := syscall.UTF16PtrFromString(volume + `\`)
+	existing, err := existingDiskPath(path)
+	if err != nil {
+		return "", err
+	}
+	pathPtr, err := syscall.UTF16PtrFromString(existing)
+	if err != nil {
+		return "", err
+	}
+	var root [32768]uint16
+	ok, _, callErr := procGetVolumePathNameW.Call(
+		uintptr(unsafe.Pointer(pathPtr)), uintptr(unsafe.Pointer(&root[0])), uintptr(len(root)),
+	)
+	if ok == 0 {
+		return "", callErr
+	}
+	return syscall.UTF16ToString(root[:]), nil
+}
+
+func dataLocationIsLocal(path string) bool {
+	root, err := dataLocationVolumeRoot(path)
 	if err != nil {
 		return false
 	}
-	driveType, _, _ := procGetDriveTypeW.Call(uintptr(unsafe.Pointer(root)))
+	rootPtr, err := syscall.UTF16PtrFromString(root)
+	if err != nil {
+		return false
+	}
+	driveType, _, _ := procGetDriveTypeW.Call(uintptr(unsafe.Pointer(rootPtr)))
 	return supportedLocalDriveType(driveType)
+}
+
+func dataLocationSupportsSparseFiles(path string) (bool, error) {
+	root, err := dataLocationVolumeRoot(path)
+	if err != nil {
+		return false, err
+	}
+	rootPtr, err := syscall.UTF16PtrFromString(root)
+	if err != nil {
+		return false, err
+	}
+	var flags uint32
+	ok, _, callErr := procGetVolumeInformationW.Call(
+		uintptr(unsafe.Pointer(rootPtr)), 0, 0, 0, 0,
+		uintptr(unsafe.Pointer(&flags)), 0, 0,
+	)
+	if ok == 0 {
+		return false, callErr
+	}
+	return flags&fileSupportsSparseFiles != 0, nil
+}
+
+func validateStandardDataDrive(path string) error {
+	if !dataLocationIsLocal(path) {
+		return fmt.Errorf("choose a folder on a local Windows drive; network and unavailable drives are not supported")
+	}
+	supported, err := dataLocationSupportsSparseFiles(path)
+	if err != nil {
+		return fmt.Errorf("checking filesystem support: %w", err)
+	}
+	if !supported {
+		return fmt.Errorf("choose an NTFS or ReFS drive; standard installs require sparse-file support")
+	}
+	return nil
 }
 
 // chooseFirstRunDataDirectory asks once, before any payload is downloaded.
@@ -50,6 +111,10 @@ func chooseFirstRunDataDirectory(defaultDir string) (string, bool, error) {
 		case idCancel:
 			return "", false, nil
 		case idNo:
+			if err := validateStandardDataDrive(defaultDir); err != nil {
+				errorBox("Try Omarchy cannot use the default location.\n\n" + err.Error() + "\n\nChoose another local drive or folder.")
+				continue
+			}
 			return defaultDir, true, nil
 		case idYes:
 			parent, ok := browseForFolder(0, "Choose a local drive or parent folder. Try Omarchy will create a TryOmarchy folder inside it.")
@@ -61,8 +126,8 @@ func chooseFirstRunDataDirectory(defaultDir string) (string, bool, error) {
 				errorBox("Try Omarchy cannot use that location.\n\n" + err.Error())
 				continue
 			}
-			if !dataLocationIsLocal(selected) {
-				errorBox("Choose a folder on a local Windows drive. Network locations are not supported for the virtual disk.")
+			if err := validateStandardDataDrive(selected); err != nil {
+				errorBox("Try Omarchy cannot use that location.\n\n" + err.Error())
 				continue
 			}
 			if err := ensureDataDirectoryWritable(selected); err != nil {

--- a/app/data_location_windows_test.go
+++ b/app/data_location_windows_test.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package main
+
+import "testing"
+
+func TestDataLocationIsLocal(t *testing.T) {
+	if !dataLocationIsLocal(t.TempDir()) {
+		t.Fatal("temporary directory was not recognized as local")
+	}
+	if dataLocationIsLocal(`\\server\share\TryOmarchy`) {
+		t.Fatal("UNC location was recognized as local")
+	}
+}

--- a/app/data_location_windows_test.go
+++ b/app/data_location_windows_test.go
@@ -11,4 +11,14 @@ func TestDataLocationIsLocal(t *testing.T) {
 	if dataLocationIsLocal(`\\server\share\TryOmarchy`) {
 		t.Fatal("UNC location was recognized as local")
 	}
+	for _, driveType := range []uintptr{0, 1, 4, 5} {
+		if supportedLocalDriveType(driveType) {
+			t.Fatalf("drive type %d was recognized as supported", driveType)
+		}
+	}
+	for _, driveType := range []uintptr{driveRemovable, driveFixed, driveRAMDisk} {
+		if !supportedLocalDriveType(driveType) {
+			t.Fatalf("drive type %d was not recognized as supported", driveType)
+		}
+	}
 }

--- a/app/data_location_windows_test.go
+++ b/app/data_location_windows_test.go
@@ -5,8 +5,15 @@ package main
 import "testing"
 
 func TestDataLocationIsLocal(t *testing.T) {
-	if !dataLocationIsLocal(t.TempDir()) {
+	dir := t.TempDir()
+	if !dataLocationIsLocal(dir) {
 		t.Fatal("temporary directory was not recognized as local")
+	}
+	if supported, err := dataLocationSupportsSparseFiles(dir); err != nil || !supported {
+		t.Fatalf("temporary directory sparse support = %v, %v", supported, err)
+	}
+	if err := validateStandardDataDrive(dir); err != nil {
+		t.Fatalf("temporary directory was not accepted: %v", err)
 	}
 	if dataLocationIsLocal(`\\server\share\TryOmarchy`) {
 		t.Fatal("UNC location was recognized as local")

--- a/app/fetch.go
+++ b/app/fetch.go
@@ -34,7 +34,7 @@ func ensureGuest(cfg *config, release, sumsSHA256 string) error {
 		return nil
 	}
 	oldRelease, oldManifest, haveOldReceipt := installReceiptIdentity(cfg.guestDir)
-	isReleaseUpdate := haveOldReceipt && (oldRelease != normalizedRelease(release) ||
+	isReleaseUpdate := haveOldReceipt && (!releaseLocationsEquivalent(oldRelease, release) ||
 		oldManifest != normalizedSHA256(sumsSHA256))
 	if !isReleaseUpdate {
 		return ensureGuestFiles(cfg, release, sumsSHA256)

--- a/app/folder_dialog_windows.go
+++ b/app/folder_dialog_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	procSHBrowseForFolderW   = shell32.NewProc("SHBrowseForFolderW")
+	procSHGetPathFromIDListW = shell32.NewProc("SHGetPathFromIDListW")
+	procCoTaskMemFree        = ole32.NewProc("CoTaskMemFree")
+)
+
+const bifReturnOnlyFS = 0x0001
+
+type browseInfo struct {
+	owner       uintptr
+	root        uintptr
+	displayName *uint16
+	title       *uint16
+	flags       uint32
+	callback    uintptr
+	param       uintptr
+	image       int32
+}
+
+func browseForFolder(owner uintptr, prompt string) (string, bool) {
+	var display [260]uint16
+	title, _ := syscall.UTF16PtrFromString(prompt)
+	bi := browseInfo{owner: owner, displayName: &display[0], title: title, flags: bifReturnOnlyFS}
+	pidl, _, _ := procSHBrowseForFolderW.Call(uintptr(unsafe.Pointer(&bi)))
+	if pidl == 0 {
+		return "", false
+	}
+	defer procCoTaskMemFree.Call(pidl)
+	var pathBuf [32768]uint16
+	if ok, _, _ := procSHGetPathFromIDListW.Call(pidl, uintptr(unsafe.Pointer(&pathBuf[0]))); ok != 0 {
+		return syscall.UTF16ToString(pathBuf[:]), true
+	}
+	return "", false
+}

--- a/app/go.mod
+++ b/app/go.mod
@@ -1,4 +1,4 @@
-module github.com/tsouth89/try-omarchy-windows/app
+module github.com/omacom/try-omarchy-windows/app
 
 go 1.27
 

--- a/app/install_state.go
+++ b/app/install_state.go
@@ -63,6 +63,25 @@ func normalizedRelease(release string) string {
 	return strings.TrimRight(strings.TrimSpace(release), "/")
 }
 
+// releaseLocationsEquivalent recognizes only the repository-transfer form of
+// the same tagged release. This prevents an owner-only URL change from looking
+// like a payload update while keeping unrelated repositories and tags distinct.
+func releaseLocationsEquivalent(a, b string) bool {
+	a = normalizedRelease(a)
+	b = normalizedRelease(b)
+	if a == b {
+		return true
+	}
+	legacyTag := strings.TrimPrefix(a, legacyReleaseBase)
+	transferredTag := strings.TrimPrefix(b, transferredReleaseBase)
+	if legacyTag != a && transferredTag != b && legacyTag != "" && legacyTag == transferredTag {
+		return true
+	}
+	legacyTag = strings.TrimPrefix(b, legacyReleaseBase)
+	transferredTag = strings.TrimPrefix(a, transferredReleaseBase)
+	return legacyTag != b && transferredTag != a && legacyTag != "" && legacyTag == transferredTag
+}
+
 func normalizedSHA256(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
 }
@@ -85,7 +104,7 @@ func installReceiptMatches(dir, release, manifestSHA256 string, names []string) 
 	var receipt installReceipt
 	if json.Unmarshal(data, &receipt) != nil ||
 		receipt.Version != installReceiptVersion ||
-		receipt.Release != normalizedRelease(release) ||
+		!releaseLocationsEquivalent(receipt.Release, release) ||
 		receipt.ManifestSHA256 != normalizedSHA256(manifestSHA256) {
 		return false, nil
 	}

--- a/app/install_state_test.go
+++ b/app/install_state_test.go
@@ -102,3 +102,23 @@ func TestInvalidInstallReceiptTriggersRecovery(t *testing.T) {
 		t.Fatal("malformed receipt was accepted")
 	}
 }
+
+func TestInstallReceiptSurvivesRepositoryTransfer(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("root filesystem")
+	if err := os.WriteFile(filepath.Join(dir, "rootfs"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := testSHA256([]byte("manifest"))
+	tag := "v0.0.11-preview"
+	if err := writeInstallReceipt(dir, legacyReleaseBase+tag, manifest, []string{"rootfs"}, map[string]string{"rootfs": testSHA256(data)}); err != nil {
+		t.Fatal(err)
+	}
+	ok, err := installReceiptMatches(dir, transferredReleaseBase+tag, manifest, []string{"rootfs"})
+	if err != nil || !ok {
+		t.Fatalf("transferred receipt = %v, %v", ok, err)
+	}
+	if releaseLocationsEquivalent(legacyReleaseBase+tag, transferredReleaseBase+"v0.0.12-preview") {
+		t.Fatal("different release tags were treated as equivalent")
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -126,6 +126,7 @@ func finishSetupCancellation(cfg *config, err error) bool {
 
 func main() {
 	cfg := &config{}
+	removeStandardDataOnCancel := false
 	defaultDir := filepath.Join(os.Getenv("LOCALAPPDATA"), defaultDataDirectoryName)
 	flag.StringVar(&cfg.dir, "dir", defaultDir, "Try Omarchy data directory (virtual machine, runtime, and settings)")
 	flag.StringVar(&cfg.winqEmu, "winq", `C:\WINQ-EMU`, "WINQ-EMU install path (GPU mode)")
@@ -209,6 +210,10 @@ func main() {
 		}
 		cfg.dir = selected
 		cfg.hostDir = cfg.dir
+		removeStandardDataOnCancel, err = dataDirectoryEmpty(cfg.dir)
+		if err != nil {
+			fatal("Try Omarchy cannot inspect its data location: %v", err)
+		}
 		if *applyLauncherUpdateFlag || *applyLauncherRollbackFlag {
 			if err := applyLauncherUpdate(cfg.dir, *updateWaitPID, *updateRestartArgs, *applyLauncherRollbackFlag); err != nil {
 				errorBox("Try Omarchy could not finish applying its update.\n\n" + err.Error())
@@ -294,7 +299,7 @@ func main() {
 	}
 	completeAtStart := completeInstallExists(cfg.dir, filepath.Base(cfg.disk))
 	needsProvisioning := cfg.fresh || !completeAtStart
-	configureSetupCancellation(!completeAtStart)
+	configureSetupCancellation(!completeAtStart && (cfg.portable || removeStandardDataOnCancel))
 	if err := os.MkdirAll(cfg.vmDir, 0o755); err != nil {
 		fatal("Could not create the Omarchy data directory: %v", err)
 	}

--- a/app/main.go
+++ b/app/main.go
@@ -202,8 +202,10 @@ func main() {
 		if !proceed {
 			return
 		}
-		if !explicitFlags["dir"] && !pathsEqual(selected, defaultDir) && !dataLocationIsLocal(selected) {
-			fatal("The saved Try Omarchy data location is not available on a supported local drive:\n\n%s\n\nReconnect the drive or delete %s to choose another location.", selected, dataLocationPointerPath(defaultDir))
+		if !explicitFlags["dir"] && !pathsEqual(selected, defaultDir) {
+			if err := validateStandardDataDrive(selected); err != nil {
+				fatal("The saved Try Omarchy data location is unavailable or incompatible:\n\n%s\n\n%v\n\nReconnect the drive or delete %s to choose another location.", selected, err, dataLocationPointerPath(defaultDir))
+			}
 		}
 		cfg.dir = selected
 		cfg.hostDir = cfg.dir

--- a/app/main.go
+++ b/app/main.go
@@ -202,6 +202,9 @@ func main() {
 		if !proceed {
 			return
 		}
+		if !explicitFlags["dir"] && !pathsEqual(selected, defaultDir) && !dataLocationIsLocal(selected) {
+			fatal("The saved Try Omarchy data location is not available on a supported local drive:\n\n%s\n\nReconnect the drive or delete %s to choose another location.", selected, dataLocationPointerPath(defaultDir))
+		}
 		cfg.dir = selected
 		cfg.hostDir = cfg.dir
 		if *applyLauncherUpdateFlag || *applyLauncherRollbackFlag {

--- a/app/main.go
+++ b/app/main.go
@@ -93,10 +93,6 @@ type buildSpec struct {
 
 var logFile *os.File
 
-// Kept as a variable so isolated signed test builds can use their own data
-// directory without changing production behavior.
-var defaultDataDirectoryName = "TryOmarchy"
-
 func logf(format string, a ...any) {
 	if logFile != nil {
 		fmt.Fprintf(logFile, "%s %s\n", time.Now().Format("15:04:05"), fmt.Sprintf(format, a...))
@@ -130,7 +126,8 @@ func finishSetupCancellation(cfg *config, err error) bool {
 
 func main() {
 	cfg := &config{}
-	flag.StringVar(&cfg.dir, "dir", filepath.Join(os.Getenv("LOCALAPPDATA"), defaultDataDirectoryName), "data directory")
+	defaultDir := filepath.Join(os.Getenv("LOCALAPPDATA"), defaultDataDirectoryName)
+	flag.StringVar(&cfg.dir, "dir", defaultDir, "Try Omarchy data directory (virtual machine, runtime, and settings)")
 	flag.StringVar(&cfg.winqEmu, "winq", `C:\WINQ-EMU`, "WINQ-EMU install path (GPU mode)")
 	flag.StringVar(&cfg.share, "share", "", "Windows folder shared into Omarchy at /mnt/host and as ~/<folder name>")
 	flag.BoolVar(&cfg.fresh, "fresh", false, "discard the writable disk and start over")
@@ -162,6 +159,8 @@ func main() {
 	updateWaitPID := flag.Int("update-wait-pid", 0, "internal: process to wait for before replacing the launcher")
 	updateRestartArgs := flag.String("update-restart-args", "", "internal: encoded launcher restart arguments")
 	flag.Parse()
+	explicitFlags := map[string]bool{}
+	flag.Visit(func(f *flag.Flag) { explicitFlags[f.Name] = true })
 	if strings.TrimSpace(*runtimeRelease) == "" {
 		*runtimeRelease = *release
 	}
@@ -173,6 +172,13 @@ func main() {
 	// code (see setup.go); it must not touch the single-instance port.
 	if *enableWhp {
 		os.Exit(runDismEnable())
+	}
+	// Bind before the first-run location prompt. Two quick launches must not
+	// race each other through the folder choice or write the same pointer and
+	// payload files. Settings, diagnostics, and update helpers remain usable
+	// while the VM owns the lifecycle port.
+	if !*openSettings && !*diagnostics && !*applyLauncherUpdateFlag && !*applyLauncherRollbackFlag {
+		runLifecycleListener()
 	}
 	if cfg.portable {
 		self, err := os.Executable()
@@ -186,6 +192,17 @@ func main() {
 		// not travel to another PC with the USB.
 		cfg.hostDir = filepath.Join(os.Getenv("LOCALAPPDATA"), "TryOmarchy", "portable-host")
 	} else {
+		promptForLocation := !*diagnostics && !*applyLauncherUpdateFlag && !*applyLauncherRollbackFlag
+		selected, proceed, err := resolveStandardDataDirectory(
+			defaultDir, cfg.dir, explicitFlags["dir"], promptForLocation, chooseFirstRunDataDirectory,
+		)
+		if err != nil {
+			fatal("Try Omarchy cannot resolve its data location: %v\n\nIf a saved location is damaged, fix or delete %s, then open Try Omarchy again.", err, dataLocationPointerPath(defaultDir))
+		}
+		if !proceed {
+			return
+		}
+		cfg.dir = selected
 		cfg.hostDir = cfg.dir
 		if *applyLauncherUpdateFlag || *applyLauncherRollbackFlag {
 			if err := applyLauncherUpdate(cfg.dir, *updateWaitPID, *updateRestartArgs, *applyLauncherRollbackFlag); err != nil {
@@ -230,8 +247,6 @@ func main() {
 
 	// settings.json holds the rows the settings window edits; explicit flags
 	// win for this launch only.
-	explicitFlags := map[string]bool{}
-	flag.Visit(func(f *flag.Flag) { explicitFlags[f.Name] = true })
 	settingsFile := settingsPath(cfg.dir)
 	userSettings, err := loadSettings(settingsFile)
 	if err != nil {
@@ -290,11 +305,6 @@ func main() {
 		os.Stderr = logFile
 	}
 	logf("---- %s starting ----", appTitle)
-
-	// Single-instance guard FIRST: binding the lifecycle port before the image
-	// fetch stops a double-click double-launch from downloading the same image
-	// into the same files twice (it happened).
-	runLifecycleListener()
 
 	// The splash IS the launch experience: it appears here and stays on screen
 	// through every phase until the Omarchy window itself is visible (the

--- a/app/manifest.go
+++ b/app/manifest.go
@@ -17,7 +17,7 @@ const maxSumsBytes = 1 << 20
 // Variables so the signed test-launcher workflow can pin an isolated release
 // with -ldflags -X. Normal builds retain these production defaults.
 var (
-	defaultReleaseURL        = "https://github.com/tsouth89/try-omarchy-windows/releases/download/v0.0.11-preview"
+	defaultReleaseURL        = "https://github.com/omacom/try-omarchy-windows/releases/download/v0.0.11-preview"
 	defaultSumsSHA256        = "dbbffa758eb5164fb2b4f41ccc6de5ddbc03d2560515ab54b5115460fcc3d1d4"
 	defaultRuntimeReleaseURL = ""
 	defaultRuntimeSumsSHA256 = ""

--- a/app/runtime_state.go
+++ b/app/runtime_state.go
@@ -40,7 +40,7 @@ func runtimeReceiptMatches(root, release, manifestSHA, archiveSHA string) bool {
 	}
 	var receipt runtimeReceipt
 	if json.Unmarshal(data, &receipt) != nil || receipt.Schema != 1 ||
-		receipt.Release != normalizedRelease(release) ||
+		!releaseLocationsEquivalent(receipt.Release, release) ||
 		receipt.ManifestSHA256 != normalizedSHA256(manifestSHA) ||
 		receipt.ArchiveSHA256 != normalizedSHA256(archiveSHA) ||
 		!validSHA256(receipt.Executable.SHA256) {

--- a/app/runtime_state_test.go
+++ b/app/runtime_state_test.go
@@ -36,3 +36,23 @@ func TestRuntimeReceiptTracksReleaseAndExecutable(t *testing.T) {
 		t.Fatal("runtime receipt survived an executable change")
 	}
 }
+
+func TestRuntimeReceiptSurvivesRepositoryTransfer(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "qemu-system-x86_64w.exe"), []byte("runtime"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifestSHA := strings.Repeat("a", 64)
+	archiveSHA := strings.Repeat("b", 64)
+	tag := "v0.0.11-preview"
+	if err := writeRuntimeReceipt(root, legacyReleaseBase+tag, manifestSHA, archiveSHA); err != nil {
+		t.Fatal(err)
+	}
+	if !runtimeReceiptMatches(root, transferredReleaseBase+tag, manifestSHA, archiveSHA) {
+		t.Fatal("runtime receipt did not survive the repository transfer")
+	}
+}

--- a/app/settings_dialog_windows.go
+++ b/app/settings_dialog_windows.go
@@ -18,17 +18,12 @@ import (
 // so it behaves like every other Windows dialog with keyboard, high DPI and
 // screen readers, unlike the custom-painted splash.
 
-// shell32 and ole32 are the package-level handles declared in setup.go and
-// taskbar.go.
 var (
-	procSHBrowseForFolderW   = shell32.NewProc("SHBrowseForFolderW")
-	procSHGetPathFromIDListW = shell32.NewProc("SHGetPathFromIDListW")
-	procCoTaskMemFree        = ole32.NewProc("CoTaskMemFree")
-	procIsDialogMessageW     = user32.NewProc("IsDialogMessageW")
-	procLoadCursorW          = user32.NewProc("LoadCursorW")
-	procGetStockObject       = syscall.NewLazyDLL("gdi32.dll").NewProc("GetStockObject")
-	procSetFocus             = user32.NewProc("SetFocus")
-	procAdjustWindowRectEx   = user32.NewProc("AdjustWindowRectEx")
+	procIsDialogMessageW   = user32.NewProc("IsDialogMessageW")
+	procLoadCursorW        = user32.NewProc("LoadCursorW")
+	procGetStockObject     = syscall.NewLazyDLL("gdi32.dll").NewProc("GetStockObject")
+	procSetFocus           = user32.NewProc("SetFocus")
+	procAdjustWindowRectEx = user32.NewProc("AdjustWindowRectEx")
 )
 
 const (
@@ -48,8 +43,6 @@ const (
 	idcArrow          = 32512
 	colorBtnface      = 15
 	defaultGuiFont    = 17
-	idCancel          = 2
-	bifReturnOnlyFS   = 0x0001
 	wmGettextlength   = 0x000E
 	wmGettext         = 0x000D
 	settingsSaveID    = 2001
@@ -95,29 +88,10 @@ func runSettingsDialog(path, dataDir string) (saved bool) {
 			text(hMem), text(hShare), text(hFwd), text(hKey))
 	}
 	browseFolder := func() {
-		var display [260]uint16
-		title, _ := syscall.UTF16PtrFromString("Choose the Windows folder to share with Omarchy")
-		type browseInfo struct {
-			owner       uintptr
-			root        uintptr
-			displayName *uint16
-			title       *uint16
-			flags       uint32
-			callback    uintptr
-			param       uintptr
-			image       int32
-		}
-		bi := browseInfo{owner: hwnd, displayName: &display[0], title: title, flags: bifReturnOnlyFS}
-		pidl, _, _ := procSHBrowseForFolderW.Call(uintptr(unsafe.Pointer(&bi)))
-		if pidl == 0 {
-			return
-		}
-		var pathBuf [1024]uint16
-		if ok, _, _ := procSHGetPathFromIDListW.Call(pidl, uintptr(unsafe.Pointer(&pathBuf[0]))); ok != 0 {
-			setText(hShare, syscall.UTF16ToString(pathBuf[:]))
+		if selected, ok := browseForFolder(hwnd, "Choose the Windows folder to share with Omarchy"); ok {
+			setText(hShare, selected)
 			procSendMessageW.Call(hShareOn, bmSetcheck, bstChecked, 0)
 		}
-		procCoTaskMemFree.Call(pidl)
 	}
 
 	wndProc := syscall.NewCallback(func(h, msg, wParam, lParam uintptr) uintptr {

--- a/app/setup.go
+++ b/app/setup.go
@@ -53,9 +53,12 @@ const (
 	mbIconInfo     = 0x40
 	mbIconQuestion = 0x20
 	mbYesNo        = 0x04
+	mbYesNoCancel  = 0x03
 	mbOkCancel     = 0x01
 	idOk           = 1
+	idCancel       = 2
 	idYes          = 6
+	idNo           = 7
 
 	seeMaskNoCloseProcess = 0x40
 	errorCancelled        = 1223 // user said No to the UAC prompt

--- a/app/shared_folder_windows.go
+++ b/app/shared_folder_windows.go
@@ -107,19 +107,28 @@ func sameWindowsPath(a, b string) bool {
 	if a == "" || b == "" {
 		return false
 	}
-	aa, errA := filepath.Abs(a)
-	bb, errB := filepath.Abs(b)
-	return errA == nil && errB == nil && strings.EqualFold(filepath.Clean(aa), filepath.Clean(bb))
+	aa, okA := canonicalWindowsComparisonPath(a)
+	bb, okB := canonicalWindowsComparisonPath(b)
+	return okA && okB && aa == bb
+}
+
+func canonicalWindowsComparisonPath(path string) (string, bool) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", false
+	}
+	if canonical, err := filepath.EvalSymlinks(path); err == nil {
+		path = canonical
+	}
+	return strings.ToLower(filepath.Clean(path)), true
 }
 
 func pathWithinWindows(path, parent string) bool {
-	path, errPath := filepath.Abs(path)
-	parent, errParent := filepath.Abs(parent)
-	if errPath != nil || errParent != nil {
+	path, okPath := canonicalWindowsComparisonPath(path)
+	parent, okParent := canonicalWindowsComparisonPath(parent)
+	if !okPath || !okParent {
 		return false
 	}
-	path = strings.ToLower(filepath.Clean(path))
-	parent = strings.ToLower(filepath.Clean(parent))
 	rel, err := filepath.Rel(parent, path)
 	return err == nil && (rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))))
 }

--- a/app/shared_folder_windows_test.go
+++ b/app/shared_folder_windows_test.go
@@ -23,8 +23,19 @@ func TestValidateWindowsSharedFolderPolicy(t *testing.T) {
 		}
 	}
 	got, err := validateWindowsSharedFolder(share, data, home)
-	if err != nil || !sameWindowsPath(got, share) {
+	if err != nil {
 		t.Fatalf("valid share = %q, %v", got, err)
+	}
+	want, err := filepath.EvalSymlinks(share)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err = filepath.Abs(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameWindowsPath(got, want) {
+		t.Fatalf("canonical share = %q, want %q", got, want)
 	}
 	if _, err := validateWindowsSharedFolder(home, data, home); err == nil {
 		t.Fatal("the whole home folder was accepted")

--- a/app/update.go
+++ b/app/update.go
@@ -16,12 +16,13 @@ import (
 )
 
 const (
-	currentVersion        = "v0.0.11-preview"
-	defaultUpdateURL      = "https://github.com/tsouth89/try-omarchy-windows/releases/latest/download/update.json"
-	legacyReleaseBase     = "https://github.com/tsouth89/try-omarchy-windows/releases/download/"
-	officialReleaseBase   = "https://github.com/omacom/omarchy-win/releases/download/"
-	maxUpdateManifestLen  = 64 << 10
-	maxUpdateSignatureLen = 4 << 10
+	currentVersion         = "v0.0.11-preview"
+	defaultUpdateURL       = "https://github.com/omacom/try-omarchy-windows/releases/latest/download/update.json"
+	legacyReleaseBase      = "https://github.com/tsouth89/try-omarchy-windows/releases/download/"
+	transferredReleaseBase = "https://github.com/omacom/try-omarchy-windows/releases/download/"
+	officialReleaseBase    = "https://github.com/omacom/omarchy-win/releases/download/"
+	maxUpdateManifestLen   = 64 << 10
+	maxUpdateSignatureLen  = 4 << 10
 	// Rotating the private half requires shipping a launcher that trusts both
 	// the old and new keys before publishing manifests signed only by the new
 	// key. The release workflow keeps the private key in the protected release
@@ -100,7 +101,8 @@ func validateUpdateManifest(manifest *updateManifest) error {
 		return fmt.Errorf("invalid update version %q", manifest.Version)
 	}
 	release := normalizedRelease(manifest.Release)
-	if release != legacyReleaseBase+manifest.Version && release != officialReleaseBase+manifest.Version {
+	if release != legacyReleaseBase+manifest.Version && release != transferredReleaseBase+manifest.Version &&
+		release != officialReleaseBase+manifest.Version {
 		return fmt.Errorf("update release URL does not match version")
 	}
 	if !validSHA256(manifest.ManifestSHA256) || !validSHA256(manifest.Launcher.SHA256) {

--- a/app/update_test.go
+++ b/app/update_test.go
@@ -38,7 +38,7 @@ func signedUpdateServer(t *testing.T, body []byte, mutateSignature bool) (*httpt
 func validUpdateJSON(version string) []byte {
 	return []byte(fmt.Sprintf(`{"schema":1,"version":%q,"release":%q,"manifestSHA256":%q,"launcher":{"name":"TryOmarchy.exe","sha256":%q}}`,
 		version,
-		"https://github.com/tsouth89/try-omarchy-windows/releases/download/"+version,
+		transferredReleaseBase+version,
 		strings.Repeat("a", 64), strings.Repeat("b", 64)))
 }
 
@@ -77,6 +77,17 @@ func TestValidateUpdateManifestAcceptsOfficialRepository(t *testing.T) {
 		t.Fatal(err)
 	}
 	manifest.Release = officialReleaseBase + manifest.Version
+	if err := validateUpdateManifest(&manifest); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateUpdateManifestAcceptsLegacyRepository(t *testing.T) {
+	var manifest updateManifest
+	if err := json.Unmarshal(validUpdateJSON("v0.0.8-preview"), &manifest); err != nil {
+		t.Fatal(err)
+	}
+	manifest.Release = legacyReleaseBase + manifest.Version
 	if err := validateUpdateManifest(&manifest); err != nil {
 		t.Fatal(err)
 	}

--- a/guest-build/runtime.lock.json
+++ b/guest-build/runtime.lock.json
@@ -1,11 +1,11 @@
 {
   "runtime": {
-    "url": "https://github.com/tsouth89/try-omarchy-windows/releases/download/v0.0.9-preview/winq-emu-alpha10-portable.zip",
+    "url": "https://github.com/omacom/try-omarchy-windows/releases/download/v0.0.9-preview/winq-emu-alpha10-portable.zip",
     "filename": "winq-emu-alpha10-portable.zip",
     "sha256": "e8d0bef993f27bc4caad507ee9da4f310073c14a92baac56ceb6ef111d801e3c"
   },
   "source": {
-    "url": "https://github.com/tsouth89/try-omarchy-windows/releases/download/v0.0.9-preview/winq-emu-alpha10-source.zip",
+    "url": "https://github.com/omacom/try-omarchy-windows/releases/download/v0.0.9-preview/winq-emu-alpha10-source.zip",
     "filename": "winq-emu-alpha10-source.zip",
     "sha256": "d29d9cacc367429561e24fe0079c95a2296709e13d6cfc9f06744b1e41fbfbfe"
   }

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -6,7 +6,7 @@
 #   powershell -ExecutionPolicy Bypass -File bootstrap.ps1
 param([string]$Dir = "$env:LOCALAPPDATA\TryOmarchy")
 $ErrorActionPreference = 'Stop'
-$release = 'https://github.com/tsouth89/try-omarchy-windows/releases/download/v0.0.3-preview'
+$release = 'https://github.com/omacom/try-omarchy-windows/releases/download/v0.0.3-preview'
 
 $id = [Security.Principal.WindowsIdentity]::GetCurrent()
 $isAdmin = ([Security.Principal.WindowsPrincipal]$id).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)

--- a/scripts/release/validate-pin.py
+++ b/scripts/release/validate-pin.py
@@ -33,7 +33,7 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("tag")
     parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
-    parser.add_argument("--repository", default="tsouth89/try-omarchy-windows")
+    parser.add_argument("--repository", default="omacom/try-omarchy-windows")
     args = parser.parse_args()
 
     if not TAG_RE.fullmatch(args.tag):

--- a/scripts/release/verify-public.ps1
+++ b/scripts/release/verify-public.ps1
@@ -4,7 +4,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$repository = 'tsouth89/try-omarchy-windows'
+$repository = 'omacom/try-omarchy-windows'
 $releasePath = if ($Latest) { 'latest/download' } else { "download/$Tag" }
 $base = "https://github.com/$repository/releases/$releasePath"
 $work = Join-Path $env:RUNNER_TEMP "try-omarchy-public-$([guid]::NewGuid())"


### PR DESCRIPTION
Adds a first-run choice between Local AppData and another local NTFS or ReFS drive or folder. Alternate locations are capability-checked, remembered, revalidated on later launches, and used by shortcuts. Existing installs, explicit `-dir`, and portable mode keep their current behavior.

Also updates active repository URLs after the transfer while preserving old signed-manifest and receipt compatibility. This addresses the install-location part of #15; disk-size control remains separate.

Checks: repeated launcher race tests and vet, native Windows tests, Windows cross-build, release helpers and pin validation, guest contract, and public release URL verification.

Before merge, smoke-test a clean first run on Windows 10 or 11 with both the default and another local drive. Confirm cancel, restart, an existing install, and unsupported storage behave as described.