### PR TITLE
Support stable updates from preview installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ on:
           - prepare
           - publish
       release_tag:
-        description: Release tag, for example v0.0.7-preview
+        description: Release tag, for example v0.0.12-preview or v1.0.0
         required: true
         type: string
 
 concurrency:
-  group: release-${{ inputs.release_tag }}
+  group: release
   cancel-in-progress: false
 
 permissions:
@@ -28,12 +28,12 @@ jobs:
     name: Validate request
     runs-on: ubuntu-latest
     steps:
-      - name: Require the default branch and a preview tag
+      - name: Require the default branch and a release tag
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           test "$GITHUB_REF" = refs/heads/master
-          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-preview$ ]]
+          [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-preview)?$ ]]
 
   prepare:
     name: Build guest draft
@@ -216,6 +216,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       RELEASE_TAG: ${{ inputs.release_tag }}
+      LEGACY_UPDATE_BRIDGE_TAG: ${{ vars.LEGACY_UPDATE_BRIDGE_TAG }}
       AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
@@ -317,6 +318,28 @@ jobs:
             -launcher ../release/TryOmarchy.exe `
             -output ../release/update.json
 
+      - name: Prepare current and legacy update feeds
+        shell: pwsh
+        run: |
+          Copy-Item release/update.json release/update-v2.json
+          Copy-Item release/update.json.sig release/update-v2.json.sig
+          if ($env:RELEASE_TAG -notlike '*-preview') {
+            if ($env:LEGACY_UPDATE_BRIDGE_TAG -notmatch '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview$') {
+              throw 'Set LEGACY_UPDATE_BRIDGE_TAG to a tested, published bridge preview before releasing stable builds'
+            }
+            $bridgeDraft = gh release view $env:LEGACY_UPDATE_BRIDGE_TAG --json isDraft --jq .isDraft
+            if ($LASTEXITCODE -ne 0 -or $bridgeDraft -ne 'false') { throw 'The bridge must be public' }
+            $newerThanBridge = python scripts/release/release-order.py $env:RELEASE_TAG $env:LEGACY_UPDATE_BRIDGE_TAG
+            if ($LASTEXITCODE -ne 0 -or $newerThanBridge -ne 'true') { throw 'Stable must be newer than the bridge' }
+            New-Item -ItemType Directory -Force bridge-metadata | Out-Null
+            gh release download $env:LEGACY_UPDATE_BRIDGE_TAG -p update-v2.json -p update-v2.json.sig -D bridge-metadata
+            if ($LASTEXITCODE -ne 0) { throw 'Could not download bridge metadata' }
+            go -C app run ./cmd/sign-update -verify-bridge ../bridge-metadata/update-v2.json -version $env:LEGACY_UPDATE_BRIDGE_TAG
+            if ($LASTEXITCODE -ne 0) { throw 'Bridge metadata verification failed' }
+            Copy-Item bridge-metadata/update-v2.json release/update.json
+            Copy-Item bridge-metadata/update-v2.json.sig release/update.json.sig
+          }
+
       - name: Upload launcher and release notes
         shell: pwsh
         run: |
@@ -326,6 +349,8 @@ jobs:
             release/TryOmarchy.exe.sha256 `
             release/update.json `
             release/update.json.sig `
+            release/update-v2.json `
+            release/update-v2.json.sig `
             --clobber
           gh release edit $env:RELEASE_TAG --target $env:GITHUB_SHA --title $env:RELEASE_TAG --notes-file release-notes.md
 
@@ -337,10 +362,24 @@ jobs:
         shell: pwsh
         run: scripts/release/verify-public.ps1 -Tag $env:RELEASE_TAG
 
-      - name: Mark release Latest
+      - name: Promote newer releases without replacing stable with preview
+        id: promote
         shell: pwsh
-        run: gh release edit $env:RELEASE_TAG --latest
+        run: |
+          $latest = gh release view --json tagName --jq .tagName
+          if ($LASTEXITCODE -ne 0) { throw 'Could not determine the current Latest release' }
+          $promote = python scripts/release/release-order.py $env:RELEASE_TAG $latest
+          if ($LASTEXITCODE -ne 0) { throw 'Could not compare release versions' }
+          if ($promote -eq 'true') {
+            gh release edit $env:RELEASE_TAG --latest
+            if ($LASTEXITCODE -ne 0) { throw 'Could not promote the release' }
+            'latest=true' >> $env:GITHUB_OUTPUT
+          } elseif ($env:RELEASE_TAG -like '*-preview') {
+            gh release edit $env:RELEASE_TAG --prerelease=true --latest=false
+            if ($LASTEXITCODE -ne 0) { throw 'Could not mark the preview release' }
+          }
 
       - name: Verify public Latest download
+        if: steps.promote.outputs.latest == 'true'
         shell: pwsh
         run: scripts/release/verify-public.ps1 -Tag $env:RELEASE_TAG -Latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - New standard installs now ask whether to use the default Local AppData folder or a different local drive or folder before downloading the runtime and guest image. Alternate locations are checked for write access and free space, remembered across launches, and carried into Start-menu and Desktop shortcuts.
 
 ### Fixes
+- Added stable-release update support, including a bridge for older preview launchers and recovery-state compatibility. Stable installs stay on stable releases.
 - Updated active download, update, issue, clone, and module links after the repository moved to `omacom`. Signed update manifests and existing guest and runtime receipts remain compatible with the old release base, so the transfer does not force a payload refresh or strand older launchers.
 
 ## v0.0.11-preview - 2026-09-03

--- a/app/cmd/sign-update/main.go
+++ b/app/cmd/sign-update/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -34,7 +35,23 @@ func main() {
 	manifestSHA := flag.String("manifest-sha256", "", "authenticated SHA256SUMS digest")
 	launcher := flag.String("launcher", "", "signed launcher path")
 	output := flag.String("output", "update.json", "manifest output path")
+	verify := flag.String("verify-bridge", "", "verify a signed bridge preview manifest without signing")
 	flag.Parse()
+	if *verify != "" {
+		data, err := readSmallFile(*verify, 64<<10)
+		if err != nil {
+			fatalf("read bridge manifest: %v", err)
+		}
+		signature, err := readSmallFile(*verify+".sig", 4<<10)
+		if err != nil {
+			fatalf("read bridge signature: %v", err)
+		}
+		key, _ := hex.DecodeString(expectedPublicKeyHex)
+		if err := verifyBridge(data, signature, *version, ed25519.PublicKey(key)); err != nil {
+			fatalf("verify bridge: %v", err)
+		}
+		return
+	}
 	if *version == "" || *release == "" || *launcher == "" || !validSHA256(*manifestSHA) {
 		fatalf("version, release, launcher, and a valid manifest-sha256 are required")
 	}
@@ -103,4 +120,41 @@ func validSHA256(value string) bool {
 func fatalf(format string, values ...any) {
 	fmt.Fprintf(os.Stderr, format+"\n", values...)
 	os.Exit(1)
+}
+
+// verifyBridge checks the original signed metadata before it is carried into
+// another release for launchers that only understand preview versions.
+func verifyBridge(data, signature []byte, version string, key ed25519.PublicKey) error {
+	if !regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview$`).MatchString(version) {
+		return fmt.Errorf("a bridge preview version is required")
+	}
+	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(signature)))
+	if err != nil || len(key) != ed25519.PublicKeySize || !ed25519.Verify(key, data, sig) {
+		return fmt.Errorf("invalid signature")
+	}
+	var manifest updateManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return err
+	}
+	if manifest.Schema != 1 || manifest.Version != version || manifest.Launcher.Name != "TryOmarchy.exe" ||
+		!validSHA256(manifest.ManifestSHA256) || !validSHA256(manifest.Launcher.SHA256) {
+		return fmt.Errorf("invalid bridge metadata")
+	}
+	for _, repo := range []string{"tsouth89/try-omarchy-windows", "omacom/try-omarchy-windows", "omacom/omarchy-win"} {
+		if manifest.Release == "https://github.com/"+repo+"/releases/download/"+version {
+			return nil
+		}
+	}
+	return fmt.Errorf("unexpected bridge release URL")
+}
+
+func readSmallFile(path string, limit int64) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Size() > limit {
+		return nil, fmt.Errorf("invalid metadata file")
+	}
+	return os.ReadFile(path)
 }

--- a/app/cmd/sign-update/main_test.go
+++ b/app/cmd/sign-update/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestVerifyBridge(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const version = "v0.0.12-preview"
+	base := updateManifest{Schema: 1, Version: version,
+		Release:        "https://github.com/tsouth89/try-omarchy-windows/releases/download/" + version,
+		ManifestSHA256: strings.Repeat("a", 64)}
+	base.Launcher.Name = "TryOmarchy.exe"
+	base.Launcher.SHA256 = strings.Repeat("b", 64)
+	for _, tc := range []struct {
+		name         string
+		mutate       func(*updateManifest)
+		badSignature bool
+		wantErr      bool
+	}{
+		{name: "valid"},
+		{name: "wrong version", mutate: func(m *updateManifest) { m.Version = "v0.0.11-preview" }, wantErr: true},
+		{name: "unexpected URL", mutate: func(m *updateManifest) { m.Release = "https://example.com/" + version }, wantErr: true},
+		{name: "bad hash", mutate: func(m *updateManifest) { m.Launcher.SHA256 = "bad" }, wantErr: true},
+		{name: "wrong executable", mutate: func(m *updateManifest) { m.Launcher.Name = "other.exe" }, wantErr: true},
+		{name: "wrong schema", mutate: func(m *updateManifest) { m.Schema = 2 }, wantErr: true},
+		{name: "invalid signature", badSignature: true, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := base
+			if tc.mutate != nil {
+				tc.mutate(&manifest)
+			}
+			data, err := json.Marshal(manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sig := ed25519.Sign(private, data)
+			if tc.badSignature {
+				sig[0] ^= 1
+			}
+			encoded := []byte(base64.StdEncoding.EncodeToString(sig))
+			if err := verifyBridge(data, encoded, version, public); (err != nil) != tc.wantErr {
+				t.Fatalf("verifyBridge error = %v, want error %v", err, tc.wantErr)
+			}
+			if err := verifyBridge(data, encoded, "v1.0.0", public); err == nil {
+				t.Fatal("stable release accepted as a legacy bridge")
+			}
+		})
+	}
+}

--- a/app/fetch.go
+++ b/app/fetch.go
@@ -187,7 +187,7 @@ func releaseVersion(release string) string {
 		return currentVersion
 	}
 	version := parts[len(parts)-1]
-	if _, ok := parsePreviewVersion(version); ok {
+	if _, ok := parseReleaseVersion(version); ok {
 		return version
 	}
 	return currentVersion

--- a/app/payload_update.go
+++ b/app/payload_update.go
@@ -102,7 +102,7 @@ func readPayloadUpdateState(dir string) (*payloadUpdateState, error) {
 	if state.Schema != payloadUpdateStateVersion {
 		return nil, fmt.Errorf("payload update state is invalid")
 	}
-	if _, ok := parsePreviewVersion(state.Version); !ok {
+	if _, ok := parseReleaseVersion(state.Version); !ok {
 		return nil, fmt.Errorf("payload update version is invalid")
 	}
 	return &state, nil

--- a/app/update.go
+++ b/app/update.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	currentVersion         = "v0.0.11-preview"
-	defaultUpdateURL       = "https://github.com/omacom/try-omarchy-windows/releases/latest/download/update.json"
+	defaultUpdateURL       = "https://github.com/omacom/try-omarchy-windows/releases/latest/download/update-v2.json"
 	legacyReleaseBase      = "https://github.com/tsouth89/try-omarchy-windows/releases/download/"
 	transferredReleaseBase = "https://github.com/omacom/try-omarchy-windows/releases/download/"
 	officialReleaseBase    = "https://github.com/omacom/omarchy-win/releases/download/"
@@ -30,7 +30,7 @@ const (
 	updatePublicKeyHex = "f1edc8c2fc8fc8a7a108832eb93a9d9f2f8c07c5547fc4e4cb805c3b1615c9cd"
 )
 
-var previewVersionPattern = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)-preview$`)
+var releaseVersionPattern = regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-preview)?$`)
 
 type updateManifest struct {
 	Schema         int    `json:"schema"`
@@ -97,7 +97,7 @@ func validateUpdateManifest(manifest *updateManifest) error {
 	if manifest.Schema != 1 {
 		return fmt.Errorf("unsupported update manifest schema %d", manifest.Schema)
 	}
-	if _, ok := parsePreviewVersion(manifest.Version); !ok {
+	if _, ok := parseReleaseVersion(manifest.Version); !ok {
 		return fmt.Errorf("invalid update version %q", manifest.Version)
 	}
 	release := normalizedRelease(manifest.Release)
@@ -127,9 +127,10 @@ func updatePublicKey() (ed25519.PublicKey, error) {
 }
 
 func updateIsNewer(candidate, current string) bool {
-	a, okA := parsePreviewVersion(candidate)
-	b, okB := parsePreviewVersion(current)
-	if !okA || !okB {
+	a, okA := parseReleaseVersion(candidate)
+	b, okB := parseReleaseVersion(current)
+	// Stable installations do not opt into preview updates.
+	if !okA || !okB || (b[3] == 1 && a[3] == 0) {
 		return false
 	}
 	for i := range a {
@@ -140,18 +141,21 @@ func updateIsNewer(candidate, current string) bool {
 	return false
 }
 
-func parsePreviewVersion(value string) ([3]int, bool) {
-	var out [3]int
-	match := previewVersionPattern.FindStringSubmatch(value)
+func parseReleaseVersion(value string) ([4]int, bool) {
+	var out [4]int
+	match := releaseVersionPattern.FindStringSubmatch(value)
 	if match == nil {
 		return out, false
 	}
-	for i := range out {
+	for i := 0; i < 3; i++ {
 		n, err := strconv.Atoi(match[i+1])
 		if err != nil {
 			return out, false
 		}
 		out[i] = n
+	}
+	if match[4] == "" {
+		out[3] = 1 // A stable release follows its preview at the same version.
 	}
 	return out, true
 }

--- a/app/update_state.go
+++ b/app/update_state.go
@@ -43,7 +43,7 @@ func readLauncherUpdateState(dir string) (*launcherUpdateState, error) {
 	if state.Schema != updateStateVersion || !validSHA256(state.SHA256) {
 		return nil, fmt.Errorf("update state is invalid")
 	}
-	if _, ok := parsePreviewVersion(state.Version); !ok {
+	if _, ok := parseReleaseVersion(state.Version); !ok {
 		return nil, fmt.Errorf("update state version is invalid")
 	}
 	return &state, nil

--- a/app/update_state_test.go
+++ b/app/update_state_test.go
@@ -88,3 +88,23 @@ func TestUpdatePathsStayInsideInstall(t *testing.T) {
 		}
 	}
 }
+
+func TestStableRecoveryStateSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	launcher := &launcherUpdateState{Schema: updateStateVersion, Version: "v1.0.0",
+		SHA256: strings.Repeat("a", 64), Started: true, HasPrevious: true}
+	if err := writeLauncherUpdateState(dir, launcher); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readLauncherUpdateState(dir)
+	if err != nil || got == nil || *got != *launcher {
+		t.Fatalf("launcher state = %+v, %v", got, err)
+	}
+	if err := recordPayloadUpdate(dir, "v1.0.0", true, true); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := readPayloadUpdateState(dir)
+	if err != nil || payload == nil || payload.Version != "v1.0.0" || !payload.GuestPending || !payload.RuntimePending {
+		t.Fatalf("payload state = %+v, %v", payload, err)
+	}
+}

--- a/app/update_test.go
+++ b/app/update_test.go
@@ -105,6 +105,17 @@ func TestUpdateVersionOrdering(t *testing.T) {
 		{"v0.0.6-preview", "v0.0.6-preview", false},
 		{"v0.0.5-preview", "v0.0.6-preview", false},
 		{"latest", "v0.0.6-preview", false},
+		{"v1.0.0", "v0.0.12-preview", true},
+		{"v1.0.0", "v1.0.0-preview", true},
+		{"v1.0.0", "v1.0.0", false},
+		{"v1.0.1", "v1.0.0", true},
+		{"v1.0.0-preview", "v1.0.0", false},
+		{"v1.1.0-preview", "v1.0.0", false},
+		{"v0.9.0", "v1.0.0-preview", false},
+		{"v01.0.0", "v0.0.12-preview", false},
+		{"v1.0.0-rc.1", "v0.0.12-preview", false},
+		{"v1.0.0+build", "v0.0.12-preview", false},
+		{"v999999999999999999999999.0.0", "v0.0.12-preview", false},
 	} {
 		if got := updateIsNewer(tc.candidate, tc.current); got != tc.newer {
 			t.Errorf("updateIsNewer(%q, %q) = %v", tc.candidate, tc.current, got)
@@ -119,5 +130,58 @@ func TestEmbeddedUpdatePublicKey(t *testing.T) {
 	}
 	if len(key) != ed25519.PublicKeySize {
 		t.Fatalf("public key length = %d", len(key))
+	}
+}
+
+func TestFetchStableUpdateAuthenticatesMetadata(t *testing.T) {
+	server, key := signedUpdateServer(t, validUpdateJSON("v1.0.0"), false)
+	defer server.Close()
+	manifest, err := fetchUpdateManifest(server.Client(), server.URL+"/update.json", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Version != "v1.0.0" {
+		t.Fatalf("version = %q", manifest.Version)
+	}
+}
+
+func TestMissedBridgeUsesSeparateSignedFeeds(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bridge := validUpdateJSON("v0.0.12-preview")
+	stable := validUpdateJSON("v1.0.0")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var data []byte
+		switch strings.TrimSuffix(r.URL.Path, ".sig") {
+		case "/update.json":
+			data = bridge
+		case "/update-v2.json":
+			data = stable
+		default:
+			http.NotFound(w, r)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, ".sig") {
+			fmt.Fprintln(w, base64.StdEncoding.EncodeToString(ed25519.Sign(private, data)))
+		} else {
+			w.Write(data)
+		}
+	}))
+	defer server.Close()
+	oldFeed, err := fetchUpdateManifest(server.Client(), server.URL+"/update.json", public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldFeed.Version != "v0.0.12-preview" || !updateIsNewer(oldFeed.Version, "v0.0.11-preview") {
+		t.Fatal("old launcher cannot reach the bridge preview")
+	}
+	newFeed, err := fetchUpdateManifest(server.Client(), server.URL+"/update-v2.json", public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updateIsNewer(newFeed.Version, oldFeed.Version) || newFeed.Version != "v1.0.0" {
+		t.Fatal("bridge cannot reach stable")
 	}
 }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -95,7 +95,7 @@ Run the `Release` workflow again with phase `publish` and the same tag. It:
 - verifies that the source pin exactly matches the draft manifest;
 - runs launcher tests and produces the optimized Windows build;
 - signs through Azure Artifact Signing using GitHub OIDC;
-- signs `update.json` with the protected Ed25519 update key;
+- signs current update metadata with the protected Ed25519 update key;
 - verifies Authenticode before upload;
 - publishes without changing `Latest`;
 - verifies the public tagged launcher, checksum, manifest, and guest URL;
@@ -104,7 +104,7 @@ Run the `Release` workflow again with phase `publish` and the same tag. It:
 If public verification fails, the release stays published but does not replace
 the previous `Latest` release.
 
-The updater accepts only a correctly signed manifest, a newer preview version,
+The updater accepts only a correctly signed manifest, a newer supported version,
 the expected repository release URL, and matching SHA256 values. It stages the
 launcher and payload directories atomically. Launcher, runtime, and guest
 updates stay rollback-capable until the guest's userspace readiness service
@@ -113,3 +113,36 @@ kernel panic cannot commit a bad update. The writable disk is
 preserved, and the updated initramfs installs the small matching launcher
 integration onto disks created by older releases without replacing their OS or
 user data.
+
+## Moving from preview to stable
+
+Ship and test a bridge preview containing the stable-version updater before
+publishing v1. Set the release environment variable `LEGACY_UPDATE_BRIDGE_TAG`
+to that published preview tag. Keep its launcher, payload, and signed metadata
+available permanently. Stable publication refuses to proceed without verified
+bridge metadata.
+
+Each release carries two signed feeds:
+
+- `update-v2.json` describes the current release and is used by the bridge and
+  all newer launchers.
+- `update.json` is for older launchers, which only accept preview tags. Preview
+  releases use their own metadata; stable releases carry the original signed
+  bridge metadata unchanged.
+
+An old installation that misses the bridge still finds it through the stable
+release's legacy feed. After installing the bridge, its next scheduled update
+check uses the current feed and can install stable. The normal Latest launcher
+link always serves the current executable. Signature verification, pinned
+payload hashes, and rollback remain required at both steps.
+
+Before v1, test an old preview against a candidate stable release with both
+feeds, then verify bridge installation, stable installation, and forced
+rollback on physical Windows with a copied guest disk. Also test a direct
+stable download and a subsequent stable update. Automated tests cover feed
+routing and recovery-state parsing, but do not replace these Windows checks.
+
+Stable installations never automatically switch to a preview. The workflow
+also prevents a later preview or older version from replacing a newer stable
+Latest release. Retain the bridge feed on every future stable release so
+infrequently used installations can still update.

--- a/scripts/release/release-order.py
+++ b/scripts/release/release-order.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Decide whether a release should replace the current Latest download."""
+
+import re
+import sys
+
+PATTERN = re.compile(r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-preview)?")
+
+
+def parse(tag):
+    match = PATTERN.fullmatch(tag)
+    if not match:
+        raise ValueError(f"invalid release tag: {tag}")
+    return (*map(int, match.group(1, 2, 3)), match.group(4) is None)
+
+
+def should_promote(candidate, current):
+    new, old = parse(candidate), parse(current)
+    return new > old and not (old[3] and not new[3])
+
+
+if __name__ == "__main__":
+    try:
+        print(str(should_promote(*sys.argv[1:])).lower())
+    except (ValueError, TypeError) as error:
+        raise SystemExit(str(error))

--- a/scripts/release/test_release_order.py
+++ b/scripts/release/test_release_order.py
@@ -1,0 +1,27 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+spec = importlib.util.spec_from_file_location("release_order", Path(__file__).with_name("release-order.py"))
+release_order = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(release_order)
+
+
+class ReleaseOrderTests(unittest.TestCase):
+    def test_transitions(self):
+        for candidate, current, expected in [
+            ("v0.0.12-preview", "v0.0.11-preview", True),
+            ("v1.0.0", "v0.0.12-preview", True),
+            ("v1.0.0", "v1.0.0-preview", True),
+            ("v1.1.0-preview", "v1.0.0", False),
+            ("v1.0.0", "v1.0.0", False),
+            ("v1.0.0", "v1.0.1", False),
+            ("v1.0.1", "v1.0.0", True),
+        ]:
+            with self.subTest(candidate=candidate, current=current):
+                self.assertEqual(release_order.should_promote(candidate, current), expected)
+
+    def test_rejects_invalid_tags(self):
+        for tag in ["latest", "v01.0.0", "v1.0.0-rc.1", "v1.0.0+build", "v1.0.0\n"]:
+            with self.subTest(tag=tag), self.assertRaises(ValueError):
+                release_order.should_promote(tag, "v0.0.11-preview")

--- a/scripts/release/test_validate_pin.py
+++ b/scripts/release/test_validate_pin.py
@@ -1,0 +1,28 @@
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class StablePinTests(unittest.TestCase):
+    def test_stable_release_pin_and_mismatched_version(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            version = re.search(r'currentVersion\s*=\s*"([^"]+)"', (ROOT / "app/update.go").read_text()).group(1)
+            for relative in ["app/manifest.go", "app/update.go", "app/cmd/sign-update/main.go"]:
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text((ROOT / relative).read_text().replace(version, "v1.0.0"))
+            fixture = root / "app/testdata/SHA256SUMS.v1.0.0"
+            fixture.parent.mkdir(parents=True)
+            fixture.write_bytes((ROOT / f"app/testdata/SHA256SUMS.{version}").read_bytes())
+            command = [sys.executable, str(ROOT / "scripts/release/validate-pin.py")]
+            result = subprocess.run(command + ["v1.0.0", "--root", str(root)], capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            result = subprocess.run(command + ["v1.0.1", "--root", str(root)], capture_output=True, text=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("currentVersion", result.stderr)

--- a/scripts/release/validate-pin.py
+++ b/scripts/release/validate-pin.py
@@ -9,7 +9,7 @@ import re
 from pathlib import Path
 
 
-TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+-preview$")
+TAG_RE = re.compile(r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-preview)?$")
 SHA_RE = re.compile(r"^[0-9a-f]{64}$")
 REQUIRED = {
     "build-spec.json",

--- a/scripts/release/verify-public.ps1
+++ b/scripts/release/verify-public.ps1
@@ -25,24 +25,29 @@ try {
     }
     if (-not $matched) { throw "$releasePath kept serving a mismatched launcher and checksum" }
 
-    $updateMatched = $false
-    if (Test-Path 'release/update.json') {
+    foreach ($feed in @('update.json', 'update-v2.json')) {
+        $updateMatched = $false
+        if (-not (Test-Path "release/$feed")) { throw "Missing local $feed" }
         for ($attempt = 1; $attempt -le 18; $attempt++) {
-            curl.exe --fail --silent --show-error --location --output "$work\update.json" "$base/update.json?attempt=$attempt"
-            curl.exe --fail --silent --show-error --location --output "$work\update.json.sig" "$base/update.json.sig?attempt=$attempt"
-            $expectedManifest = (Get-FileHash 'release/update.json' -Algorithm SHA256).Hash
-            $actualManifest = (Get-FileHash "$work\update.json" -Algorithm SHA256).Hash
-            $expectedSignature = (Get-FileHash 'release/update.json.sig' -Algorithm SHA256).Hash
-            $actualSignature = (Get-FileHash "$work\update.json.sig" -Algorithm SHA256).Hash
-            $manifestMatches = $expectedManifest -eq $actualManifest
-            $signatureMatches = $expectedSignature -eq $actualSignature
-            if ($manifestMatches -and $signatureMatches) {
-                $updateMatched = $true
-                break
+            curl.exe --fail --silent --show-error --location --output "$work\$feed" "$base/$($feed)?attempt=$attempt"
+            $metadataOK = $LASTEXITCODE -eq 0
+            curl.exe --fail --silent --show-error --location --output "$work\$feed.sig" "$base/$($feed).sig?attempt=$attempt"
+            $signatureOK = $LASTEXITCODE -eq 0
+            if ($metadataOK -and $signatureOK) {
+                $manifestMatches = (Get-FileHash "release/$feed").Hash -eq (Get-FileHash "$work\$feed").Hash
+                $signatureMatches = (Get-FileHash "release/$feed.sig").Hash -eq (Get-FileHash "$work\$feed.sig").Hash
+                if ($manifestMatches -and $signatureMatches) {
+                    $updateMatched = $true
+                    break
+                }
             }
             Start-Sleep -Seconds 10
         }
-        if (-not $updateMatched) { throw "$releasePath kept serving stale update metadata" }
+        if (-not $updateMatched) { throw "$releasePath kept serving stale $feed metadata" }
+    }
+    $current = Get-Content "$work\update-v2.json" -Raw | ConvertFrom-Json
+    if ($current.version -ne $Tag -or $current.launcher.sha256 -ne $actual) {
+        throw 'Current update metadata does not match the public launcher and requested version'
     }
 
     if (-not $Latest) {


### PR DESCRIPTION
Older launchers only accept preview versions. Add stable-version support and separate signed update feeds so installations that skip the bridge preview can still reach v1. Stable installs stay on stable releases.

The release workflow verifies bridge metadata before publishing stable builds and keeps later previews from replacing a stable Latest release.

Tested: Go race tests, vet, Windows build, release-helper tests, and PowerShell syntax. The physical Windows update and rollback checks remain open in #14.
