### PR TITLE
Add guest disk capacity controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Features
+- Added disk-capacity controls for standard installs, with in-place growth, current capacity and Windows free-space information. Lowering the setting never shrinks an existing disk.
 - New standard installs now ask whether to use the default Local AppData folder or a different local drive or folder before downloading the runtime and guest image. Alternate locations are checked for write access and free space, remembered across launches, and carried into Start-menu and Desktop shortcuts.
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -127,6 +127,22 @@ forwards (`-forward`), and `sshKey` is the public key file to authorize when a
 forward targets sshd (`-ssh-key`). Open Settings from the tray, the Start menu,
 or `TryOmarchy.exe -settings`. Changes apply on the next launch.
 
+### Disk capacity
+
+Open Settings and set **Disk capacity (GiB)**, or launch with `-disk-size 64`.
+Standard installs accept 24 to 1024 GiB; 0 keeps the release default. The next
+launch grows an existing disk in place and preserves its files. Lowering the
+setting never shrinks the disk. A fresh guest uses at least the factory image's
+required capacity.
+
+Capacity is a limit, not space reserved on Windows. The sparse disk uses host
+storage as you add files. Settings shows the current capacity and free space on
+the Windows drive. Keep important files backed up outside the guest.
+
+This preference is saved separately in `storage.json` so older launchers can
+still read their settings after rollback. An explicit `-disk-size` applies only
+to that launch. Portable QCOW2 disks keep their existing capacity.
+
 ### SSH and port forwarding
 
 Nothing listens by default. To reach Omarchy from Windows tools, forward a

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -19,6 +19,7 @@ import (
 // images, no payloads, nothing outside the data directory. Paths inside the
 // bundle mirror the data directory so a reader knows where each file lived.
 var diagnosticFiles = []string{
+	storageSettingsFilename,
 	"guest/" + installReceiptFilename,
 	"runtime/" + runtimeReceiptFilename,
 	updateStateFilename,

--- a/app/main.go
+++ b/app/main.go
@@ -48,6 +48,7 @@ type config struct {
 	sshKey   string
 	// Guest RAM chosen by the user (settings.json or -memory); 0 = automatic.
 	memOverrideMiB int
+	diskGiB        int
 	irqchipOff     bool
 }
 
@@ -134,6 +135,7 @@ func main() {
 	flag.BoolVar(&cfg.fresh, "fresh", false, "discard the writable disk and start over")
 	flag.BoolVar(&cfg.fullscreen, "fullscreen", false, "start fullscreen (Immersive)")
 	flag.IntVar(&cfg.memOverrideMiB, "memory", 0, "guest RAM in MiB (default: sized to this PC)")
+	flag.IntVar(&cfg.diskGiB, "disk-size", 0, "guest disk capacity in GiB (0: default; grows existing standard disks, never shrinks)")
 	flag.BoolVar(&cfg.noGpu, "nogpu", false, "force CPU rendering even if WINQ-EMU is installed")
 	flag.BoolVar(&cfg.hostCursor, "host-cursor", false, "force the legacy Windows cursor over the guest")
 	flag.BoolVar(&cfg.instant, "instant", false, "skip first-boot questions and use the trial account")
@@ -249,7 +251,7 @@ func main() {
 	}
 
 	if *openSettings {
-		if runSettingsDialog(settingsPath(cfg.dir), cfg.dir) {
+		if runSettingsDialog(settingsPath(cfg.dir), cfg.dir, cfg.portable) {
 			logf("settings saved to %s", settingsPath(cfg.dir))
 		}
 		return
@@ -267,6 +269,16 @@ func main() {
 	}
 	if cfg.memOverrideMiB != 0 && (cfg.memOverrideMiB < minimumGuestMemoryMiB || cfg.memOverrideMiB > maximumGuestMemoryMiB) {
 		fatal("-memory must be between %d and %d MiB.", minimumGuestMemoryMiB, maximumGuestMemoryMiB)
+	}
+	if !explicitFlags["disk-size"] {
+		storage, err := loadStorageSettings(cfg.dir)
+		if err != nil {
+			fatal("Cannot read storage preferences: %v", err)
+		}
+		cfg.diskGiB = storage.DiskGiB
+	}
+	if _, err := requestedDiskMiB(24*1024, cfg.diskGiB, cfg.portable); err != nil {
+		fatal("%v", err)
 	}
 	home, _ := os.UserHomeDir()
 	sshKey, err := resolveSSHPreset(&forwards, *sshPort, *sshKeyPath, home, explicitFlags["ssh-key"])

--- a/app/qemu.go
+++ b/app/qemu.go
@@ -142,8 +142,9 @@ func prepareDisk(cfg *config, expandedMiB int64) error {
 	if err := checkSetupCancelled(); err != nil {
 		return err
 	}
-	if expandedMiB <= 0 || expandedMiB > (1<<63-1)/(1024*1024) {
-		return fmt.Errorf("invalid expanded disk size: %d MiB", expandedMiB)
+	expandedMiB, err := requestedDiskMiB(expandedMiB, cfg.diskGiB, cfg.portable)
+	if err != nil {
+		return err
 	}
 	expandedBytes := expandedMiB * 1024 * 1024
 	if cfg.fresh {

--- a/app/qemu_nonwindows_test.go
+++ b/app/qemu_nonwindows_test.go
@@ -31,6 +31,7 @@ type config struct {
 	sshKey                   string
 	// Guest RAM chosen by the user (settings.json or -memory); 0 = automatic.
 	memOverrideMiB int
+	diskGiB        int
 	irqchipOff     bool
 }
 

--- a/app/settings_dialog_windows.go
+++ b/app/settings_dialog_windows.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -20,6 +21,7 @@ import (
 
 var (
 	procIsDialogMessageW   = user32.NewProc("IsDialogMessageW")
+	procEnableWindow       = user32.NewProc("EnableWindow")
 	procLoadCursorW        = user32.NewProc("LoadCursorW")
 	procGetStockObject     = syscall.NewLazyDLL("gdi32.dll").NewProc("GetStockObject")
 	procSetFocus           = user32.NewProc("SetFocus")
@@ -54,11 +56,12 @@ const (
 	settingsFwdID     = 2013
 	settingsKeyID     = 2014
 	settingsShareOnID = 2015
+	settingsDiskID    = 2016
 )
 
 // runSettingsDialog shows the window and returns once it closes. saved is
 // true when the file was written.
-func runSettingsDialog(path, dataDir string) (saved bool) {
+func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 	runtime.LockOSThread()
 	current, err := loadSettings(path)
 	if err != nil {
@@ -66,10 +69,15 @@ func runSettingsDialog(path, dataDir string) (saved bool) {
 		return false
 	}
 
+	storage, err := loadStorageSettings(dataDir)
+	if err != nil {
+		errorBox("Try Omarchy cannot read its storage preferences:\n\n" + err.Error())
+		return false
+	}
 	hInst, _, _ := procGetModuleHandleW.Call(0)
 	className, _ := syscall.UTF16PtrFromString("TryOmarchySettings")
 	var hwnd uintptr
-	var hFull, hMem, hShare, hShareOn, hFwd, hKey uintptr
+	var hFull, hMem, hDisk, hShare, hShareOn, hFwd, hKey uintptr
 
 	text := func(handle uintptr) string {
 		n, _, _ := procSendMessageW.Call(handle, wmGettextlength, 0, 0)
@@ -100,6 +108,10 @@ func runSettingsDialog(path, dataDir string) (saved bool) {
 			switch wParam & 0xffff {
 			case settingsSaveID:
 				s, err := collect()
+				diskGiB := storage.DiskGiB
+				if err == nil && !portable {
+					diskGiB, err = parseDiskGiB(text(hDisk))
+				}
 				if err == nil && s.activeShare() != "" {
 					home, homeErr := os.UserHomeDir()
 					if homeErr != nil {
@@ -110,6 +122,12 @@ func runSettingsDialog(path, dataDir string) (saved bool) {
 				}
 				if err == nil {
 					err = saveSettings(path, s)
+				}
+				if err == nil && !portable && diskGiB != storage.DiskGiB {
+					if storageErr := saveStorageSettings(dataDir, diskGiB); storageErr != nil {
+						errorBox("Other settings were saved, but disk capacity could not be saved:\n\n" + storageErr.Error())
+						return 0
+					}
 				}
 				if err != nil {
 					errorBox("These settings cannot be saved:\n\n" + err.Error())
@@ -152,7 +170,7 @@ func runSettingsDialog(path, dataDir string) (saved bool) {
 		return false
 	}
 
-	const clientW, clientH = 480, 400
+	const clientW, clientH = 480, 488
 	rect := [4]int32{0, 0, clientW, clientH}
 	style := uintptr(wsCaption | wsSysmenu)
 	procAdjustWindowRectEx.Call(uintptr(unsafe.Pointer(&rect[0])), style, 0, 0)
@@ -187,6 +205,29 @@ func runSettingsDialog(path, dataDir string) (saved bool) {
 	mk("STATIC", "Guest memory (MiB)", left, y+3, labelW, 20, ssNoprefix, 0)
 	hMem = mk("EDIT", strconv.Itoa(current.MemoryMiB), fieldX, y, 100, 24, wsBorder|wsTabstop|esAutohscroll, settingsMemID)
 	y += 34
+	mk("STATIC", "Disk capacity (GiB)", left, y+3, labelW, 20, ssNoprefix, 0)
+	hDisk = mk("EDIT", strconv.Itoa(storage.DiskGiB), fieldX, y, 100, 24, wsBorder|wsTabstop|esAutohscroll, settingsDiskID)
+	if portable {
+		procEnableWindow.Call(hDisk, 0)
+	}
+	y += 28
+	capacityHelp := "0 keeps the default. Increasing grows the disk next launch; lowering never shrinks it. Space is used as files are added."
+	if portable {
+		capacityHelp = "Portable disks keep their existing capacity."
+	}
+	mk("STATIC", capacityHelp, left, y, clientW-2*left, 36, ssNoprefix, 0)
+	y += 38
+	status := ""
+	if !portable {
+		if info, err := os.Stat(filepath.Join(dataDir, "vm", "disk.raw")); err == nil {
+			status = "Current capacity: " + formatGiB(info.Size()) + ". "
+		}
+	}
+	if available, err := diskFreeBytes(dataDir); err == nil {
+		status += "Free on Windows drive: " + formatGiB(available) + "."
+	}
+	mk("STATIC", status, left, y, clientW-2*left, 20, ssNoprefix, 0)
+	y += 26
 	mk("STATIC", "Shared folder", left, y+3, labelW, 20, ssNoprefix, 0)
 	hShare = mk("EDIT", current.Share, fieldX, y, fieldW-80, 24, wsBorder|wsTabstop|esAutohscroll, settingsShareID)
 	mk("BUTTON", "Browse...", fieldX+fieldW-72, y, 72, 24, wsTabstop, settingsBrowseID)
@@ -204,7 +245,7 @@ func runSettingsDialog(path, dataDir string) (saved bool) {
 	mk("STATIC", "SSH public key file\n(blank: your ~/.ssh/id_*.pub)", left, y+3, labelW, 40, ssNoprefix, 0)
 	hKey = mk("EDIT", current.SSHKey, fieldX, y, fieldW, 24, wsBorder|wsTabstop|esAutohscroll, settingsKeyID)
 	y += 36
-	mk("STATIC", "Saved to settings.json and used on the next launch. A flag on the command line wins for that launch.",
+	mk("STATIC", "Changes apply the next time Omarchy starts.",
 		left, y, clientW-2*left, 36, ssNoprefix, 0)
 	mk("BUTTON", "Save", clientW-16-180, clientH-40, 84, 26, bsDefpushbutton|wsTabstop, settingsSaveID)
 	mk("BUTTON", "Cancel", clientW-16-84, clientH-40, 84, 26, wsTabstop, settingsCancelID)

--- a/app/storage.go
+++ b/app/storage.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const storageSettingsFilename = "storage.json"
+const maximumDiskGiB = 1024
+
+// Storage preferences live separately so rollback to an older launcher, which
+// rejects unknown settings.json fields, remains possible after choosing a size.
+type storageSettings struct {
+	SchemaVersion int `json:"schemaVersion"`
+	DiskGiB       int `json:"diskGiB"`
+}
+
+func validateDiskGiB(size int) error {
+	if size != 0 && (size < 24 || size > maximumDiskGiB) {
+		return fmt.Errorf("disk capacity must be 0 (default) or between 24 and %d GiB", maximumDiskGiB)
+	}
+	return nil
+}
+
+func parseDiskGiB(value string) (int, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+	size, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("disk capacity must be a whole number of GiB")
+	}
+	return size, validateDiskGiB(size)
+}
+
+func loadStorageSettings(dir string) (storageSettings, error) {
+	defaults := storageSettings{SchemaVersion: 1}
+	f, err := os.Open(filepath.Join(dir, storageSettingsFilename))
+	if os.IsNotExist(err) {
+		return defaults, nil
+	}
+	if err != nil {
+		return defaults, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, 4097))
+	if err != nil {
+		return defaults, err
+	}
+	if len(data) > 4096 {
+		return defaults, fmt.Errorf("storage preferences are too large")
+	}
+	var settings storageSettings
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&settings); err != nil {
+		return defaults, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return defaults, fmt.Errorf("storage preferences contain trailing data")
+	}
+	if settings.SchemaVersion != 1 {
+		return defaults, fmt.Errorf("unsupported storage preferences version")
+	}
+	return settings, validateDiskGiB(settings.DiskGiB)
+}
+
+func saveStorageSettings(dir string, size int) error {
+	if err := validateDiskGiB(size); err != nil {
+		return err
+	}
+	data, err := json.Marshal(storageSettings{SchemaVersion: 1, DiskGiB: size})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(dir, ".storage-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(f.Name(), filepath.Join(dir, storageSettingsFilename))
+}
+
+func requestedDiskMiB(factoryMiB int64, requestedGiB int, portable bool) (int64, error) {
+	if factoryMiB <= 0 || factoryMiB > (1<<63-1)/(1024*1024) {
+		return 0, fmt.Errorf("invalid expanded disk size: %d MiB", factoryMiB)
+	}
+	if err := validateDiskGiB(requestedGiB); err != nil {
+		return 0, err
+	}
+	if portable && requestedGiB != 0 {
+		return 0, fmt.Errorf("custom disk capacity is not supported in portable mode; use 0 to keep the existing portable disk")
+	}
+	requestedMiB := int64(requestedGiB) * 1024
+	if requestedMiB > factoryMiB {
+		return requestedMiB, nil
+	}
+	return factoryMiB, nil
+}

--- a/app/storage_test.go
+++ b/app/storage_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStoragePreferencesRemainCompatibleWithOldSettings(t *testing.T) {
+	root := t.TempDir()
+	original := []byte(`{"schemaVersion":1,"memoryMiB":2048}`)
+	if err := os.WriteFile(settingsPath(root), original, 0600); err != nil {
+		t.Fatal(err)
+	}
+	defaults, err := loadStorageSettings(root)
+	if err != nil || defaults.DiskGiB != 0 {
+		t.Fatalf("defaults = %+v, %v", defaults, err)
+	}
+	for _, size := range []int{64, 128, 0} {
+		if err := saveStorageSettings(root, size); err != nil {
+			t.Fatal(err)
+		}
+		got, err := loadStorageSettings(root)
+		if err != nil || got.DiskGiB != size {
+			t.Fatalf("preferences = %+v, %v", got, err)
+		}
+		old, err := loadSettings(settingsPath(root))
+		if err != nil || old.MemoryMiB != 2048 {
+			t.Fatalf("old settings = %+v, %v", old, err)
+		}
+		data, err := os.ReadFile(settingsPath(root))
+		if err != nil || string(data) != string(original) {
+			t.Fatal("existing settings changed")
+		}
+	}
+	if err := saveStorageSettings(root, -1); err == nil {
+		t.Fatal("invalid capacity saved")
+	}
+	got, err := loadStorageSettings(root)
+	if err != nil || got.DiskGiB != 0 {
+		t.Fatal("invalid save changed the preference")
+	}
+}
+
+func TestStoragePreferencesRejectCorruption(t *testing.T) {
+	for _, data := range []string{
+		`{`, `{"schemaVersion":2}`, `{"schemaVersion":1,"diskGiB":-1}`,
+		`{"schemaVersion":1,"diskGiB":64} {}`, `{"schemaVersion":1,"unknown":1}`,
+	} {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, storageSettingsFilename), []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := loadStorageSettings(root); err == nil {
+			t.Fatalf("accepted %s", data)
+		}
+	}
+}
+
+func TestRequestedCapacityAndPortableGuard(t *testing.T) {
+	for _, tc := range []struct {
+		requested int
+		portable  bool
+		want      int64
+		bad       bool
+	}{
+		{0, false, 24 * 1024, false}, {64, false, 64 * 1024, false},
+		{24, false, 24 * 1024, false}, {1024, false, 1024 * 1024, false},
+		{-1, false, 0, true}, {23, false, 0, true}, {1025, false, 0, true},
+		{0, true, 24 * 1024, false}, {64, true, 0, true},
+	} {
+		got, err := requestedDiskMiB(24*1024, tc.requested, tc.portable)
+		if (err != nil) != tc.bad || (!tc.bad && got != tc.want) {
+			t.Fatalf("request %+v = %d, %v", tc, got, err)
+		}
+	}
+	if got, err := requestedDiskMiB(32*1024, 24, false); err != nil || got != 32*1024 {
+		t.Fatal("preference reduced the factory minimum")
+	}
+	for _, input := range []string{"-1", "23", "1025", "24.5", "no", "999999999999999999999"} {
+		if _, err := parseDiskGiB(input); err == nil {
+			t.Fatalf("accepted %q", input)
+		}
+	}
+}
+
+func TestCapacityGrowthPreservesDataAndNeverShrinks(t *testing.T) {
+	root := t.TempDir()
+	guest := filepath.Join(root, "guest")
+	vm := filepath.Join(root, "vm")
+	for _, path := range []string{guest, vm} {
+		if err := os.Mkdir(path, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(guest, "rootfs.ext4"), []byte("factory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	disk := filepath.Join(vm, "disk.raw")
+	content := []byte("existing guest files")
+	if err := os.WriteFile(disk, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config{dir: root, guestDir: guest, vmDir: vm, disk: disk, diskGiB: 24}
+	if err := prepareDisk(cfg, 1); err != nil {
+		t.Fatal(err)
+	}
+	cfg.diskGiB = 0
+	if err := prepareDisk(cfg, 1); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(disk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	got := make([]byte, len(content))
+	if _, err := f.Read(got); err != nil || string(got) != string(content) {
+		t.Fatalf("data changed: %q, %v", got, err)
+	}
+	info, err := f.Stat()
+	if err != nil || info.Size() != 24<<30 {
+		t.Fatalf("disk shrank: %v, %v", info, err)
+	}
+}
+
+func TestInvalidCapacityCannotResetDisk(t *testing.T) {
+	for _, portable := range []bool{false, true} {
+		root := t.TempDir()
+		disk := filepath.Join(root, "disk")
+		if err := os.WriteFile(disk, []byte("keep"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		size := -1
+		if portable {
+			size = 64
+		}
+		cfg := &config{dir: root, disk: disk, fresh: true, portable: portable, diskGiB: size}
+		if err := prepareDisk(cfg, 24*1024); err == nil {
+			t.Fatal("invalid request accepted")
+		}
+		data, err := os.ReadFile(disk)
+		if err != nil || string(data) != "keep" {
+			t.Fatal("invalid request deleted the disk")
+		}
+	}
+}


### PR DESCRIPTION
Add disk-capacity controls to Settings and a `-disk-size` option for standard installs. Existing disks grow in place; lowering the setting never shrinks them. Settings also shows current capacity and Windows free space.

Storage preferences stay separate from the older settings format so launcher rollback remains compatible. Portable disks keep their current behavior.

Tested: Go race tests, vet, Windows build, preserved data after growth, no shrinking, and rejection of invalid requests before reset. Physical Windows resize and UI checks remain pending.

Part of #15.
