### PR TITLE
Track v1 readiness and Windows validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Download, boot, Hyprland.
 - First boot offers an instant trial account or Omarchy's normal personalized account setup, with SDDM autologin after either path. Instant mode keeps `omarchy` as both the local username and lock-screen password, shows that on the setup splash, and repeats it once on the first desktop. Sudo remains passwordless in this disposable local trial.
 - Reproducible x86_64 guest image build (containerized, package-locked, pinned Omarchy revision) and a headless QMP control plane for automated testing.
 
-See [app compatibility](docs/COMPATIBILITY.md) for package support and current VM limitations.
+See [app compatibility](docs/COMPATIBILITY.md) for package support and current VM limitations. The [v1 checklist](docs/V1-READINESS.md) tracks the remaining release work.
 
 | First run | Screensaver |
 |---|---|

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -24,6 +24,6 @@ Try Omarchy runs the full x86_64 Arch Linux environment used by Omarchy. It is n
 - Text clipboard sharing works in both directions. File clipboard and drag and
   drop are not implemented yet; use the shared folder for files.
 - The launcher boots its pinned kernel and initramfs from the release image. Ordinary package installation is supported, but replacing the guest kernel independently can leave it out of sync with those boot files.
-- There is not yet a built-in snapshot, export, or migration workflow. Keep important work somewhere you also back up outside the guest.
+- Configuration export and restore are available through `try-omarchy-export`; see [the migration guide](MIGRATION.md). Full VM backups and snapshots are not built in yet. Back up important work outside the guest.
 
 Compatibility varies with Windows, CPU, GPU, and driver combinations. When reporting a problem, include those details and whether Try Omarchy selected GPU or CPU rendering.

--- a/docs/RUNTIME-VALIDATION.md
+++ b/docs/RUNTIME-VALIDATION.md
@@ -21,4 +21,4 @@ runtime pin unchanged until all of these pass on supported Windows versions.
   `qemu-stderr.log` shows the "nested virtualization unavailable" warning
   instead of `Failed to enable nested virtualization` (issue #19).
 
-Test at least one AMD, Intel, and NVIDIA host before changing the public pin.
+Test at least one AMD, Intel, and NVIDIA graphics configuration before changing the public pin. Record the launcher version, runtime hash, Windows build, and driver version using [TESTING.md](TESTING.md).

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,72 @@
+# Testing a Windows release candidate
+
+Use a separate data folder and a copy of any existing guest. Keep the original
+backup untouched. Follow [RELEASING.md](RELEASING.md) for running a signed draft
+candidate against locally served, authenticated assets.
+
+## Report details
+
+Copy this into #10 or the relevant issue. Mark untested items as untested.
+
+```text
+Launcher version and SHA256:
+Runtime archive SHA256:
+Guest release; fresh install or upgraded from:
+Windows edition, version, and build:
+CPU:
+GPU and driver version:
+RAM:
+Physical machine or nested VM:
+Full Hyper-V enabled; WSL2 installed:
+Data filesystem and drive free space:
+GPU rendering or CPU fallback:
+Results and steps for any failure:
+```
+
+Use diagnostics from the tray or `TryOmarchy.exe -diagnostics` for failures.
+Review the zip before attaching it; logs can contain local paths and other
+personal details. Do not upload the guest disk or a full backup.
+
+## Everyday use
+
+- [ ] Fresh install at the default location and another local drive.
+- [ ] Cancel a download, relaunch, and finish setup without a broken install.
+- [ ] Instant account and personalized account both reach the desktop.
+- [ ] GPU rendering, then CPU fallback, both reach the desktop.
+- [ ] Keyboard and Windows key work only in the intended window; host shortcuts
+  still work after switching away. Windows handles Win+L itself.
+- [ ] Text clipboard works in both directions; shared files can be read and
+  written from both sides.
+- [ ] Audio playback, device switching, and video work. Note microphone activity
+  at idle and when an app starts and stops recording.
+- [ ] Resize, fullscreen, and movement between monitors with different scaling.
+- [ ] Guest reboot, poweroff, relaunch, Windows sleep, and resume.
+- [ ] At least one hour of use without the launcher exiting or input forwarding
+  stopping. Report idle CPU after five minutes without animation.
+- [ ] RDP and VNC sessions, including Ctrl+Alt+G as the input fallback.
+
+## Data and update recovery
+
+Create a few identifiable files before each test and compare them afterwards.
+Use the copied guest for interruption and low-space tests.
+
+- [ ] An existing guest upgrades without replacing its OS, account, or files.
+- [ ] Interrupt the first updated boot before readiness, then relaunch. Previous
+  launcher and payloads return and the existing files remain readable.
+- [ ] A preview that misses the bridge installs the bridge first, then stable
+  on its next update check. Test direct stable install and stable-to-stable too.
+- [ ] Grow the disk, verify capacity inside Omarchy with `df -h /`, and check the
+  files. Lowering the preference and rolling back the launcher never shrink it.
+- [ ] Low host free space produces a useful error and leaves the existing guest
+  usable after space is freed.
+- [ ] Configuration export restores the selected theme, personal configuration,
+  and added packages on a separate fresh Omarchy installation.
+
+## Coverage
+
+Track results for Intel and AMD CPUs, integrated and discrete Intel/AMD/NVIDIA
+GPUs, Windows Home and Pro, and each advertised Windows version. Include a
+physical system with full Hyper-V enabled and a lower-memory host. A nested VM
+helps with automation but cannot replace physical GPU and hypervisor coverage.
+
+The runtime-specific checks remain in [RUNTIME-VALIDATION.md](RUNTIME-VALIDATION.md).

--- a/docs/V1-READINESS.md
+++ b/docs/V1-READINESS.md
@@ -1,0 +1,52 @@
+# v1 readiness
+
+The Windows app and the Mac app now live under Omacom. A stable Windows release
+still needs the checks below. A passing build does not establish hardware or
+upgrade reliability.
+
+## Work in review
+
+- [#34](https://github.com/omacom/try-omarchy-windows/pull/34): stable updates,
+  including a bridge for installations that skip preview releases.
+- [#35](https://github.com/omacom/try-omarchy-windows/pull/35): disk capacity,
+  in-place growth, and Windows free-space information.
+- [#29](https://github.com/omacom/try-omarchy-windows/pull/29): official artwork,
+  current resources, and splash icon handling.
+- First-run install-location selection is on master and needs release testing.
+
+## Release gates
+
+- [ ] Reproduce and resolve the configuration report in #32, or document its
+  confirmed cause and supported fix.
+- [ ] Test the signed candidate on the Windows hardware matrix in #10, including
+  the source runtime (#12), full Hyper-V (#4), and remote input (#3).
+- [ ] Record fresh install, existing guest upgrade, interrupted update, and
+  forced rollback (#14). Include an old preview that skips the bridge and
+  reaches stable through both signed update feeds.
+- [ ] Verify disk growth inside the guest, unchanged user files, and unchanged
+  capacity after lowering the setting or rolling back the launcher (#15).
+- [ ] Restore a configuration export onto a fresh physical Omarchy install (#5).
+  Confirm package and theme restoration and exclusion of VM-specific state.
+- [ ] Finish stopped-VM backup/restore and a clear reset flow before presenting
+  the guest as suitable for persistent work. Configuration export is not a VM
+  backup.
+- [ ] Exercise sleep/resume, mixed-DPI resize, audio-device changes, and a long
+  session. Record idle CPU and whether launch alone activates the microphone.
+- [ ] Agree release ownership, signing access and recovery, branding, download
+  location, support routing, and shared Mac/Windows behavior with maintainers.
+- [ ] Update user documentation to describe the tested release, including how
+  existing guests receive Omarchy OS updates separately from launcher updates.
+
+Use [TESTING.md](TESTING.md) for reports. Each gate needs evidence for the exact
+candidate version and runtime, not only an earlier preview. Keep release
+publication separate from code review and merging.
+
+## Scope
+
+v1 should provide a dependable way to try Omarchy, keep a trial setup, and take
+its configuration to a full installation. Prioritize reliability, storage,
+recovery, and understandable controls.
+
+Image clipboard and better file transfers can follow the core work. Camera
+bridging, Windows ARM64, and additional portable launchers remain later work.
+Booting an existing physical installation is outside the v1 scope.

--- a/docs/V1-READINESS.md
+++ b/docs/V1-READINESS.md
@@ -4,7 +4,7 @@ The Windows app and the Mac app now live under Omacom. A stable Windows release
 still needs the checks below. A passing build does not establish hardware or
 upgrade reliability.
 
-## Work in review
+## Merged for release testing
 
 - [#34](https://github.com/omacom/try-omarchy-windows/pull/34): stable updates,
   including a bridge for installations that skip preview releases.

--- a/docs/V1-READINESS.md
+++ b/docs/V1-READINESS.md
@@ -27,13 +27,13 @@ upgrade reliability.
   capacity after lowering the setting or rolling back the launcher (#15).
 - [ ] Restore a configuration export onto a fresh physical Omarchy install (#5).
   Confirm package and theme restoration and exclusion of VM-specific state.
-- [ ] Finish stopped-VM backup/restore and a clear reset flow before presenting
+- [ ] Finish stopped-VM backup/restore and a clear reset flow (#36) before presenting
   the guest as suitable for persistent work. Configuration export is not a VM
   backup.
 - [ ] Exercise sleep/resume, mixed-DPI resize, audio-device changes, and a long
   session. Record idle CPU and whether launch alone activates the microphone.
 - [ ] Agree release ownership, signing access and recovery, branding, download
-  location, support routing, and shared Mac/Windows behavior with maintainers.
+  location, support routing, and shared Mac/Windows behavior with maintainers (#37).
 - [ ] Update user documentation to describe the tested release, including how
   existing guests receive Omarchy OS updates separately from launcher updates.
 


### PR DESCRIPTION
Add a v1 checklist and a reusable Windows test report covering hardware, updates, rollback, storage, and migration. Keep the remaining release decisions and later feature work explicit.

Also correct the compatibility guide: configuration export already ships; full VM backup does not.

Checked the links and current issue/PR references. No runtime changes.
