### PR TITLE
Document runtime and update release checks

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -50,6 +50,11 @@ personal details. Do not upload the guest disk or a full backup.
 Create a few identifiable files before each test and compare them afterwards.
 Use the copied guest for interruption and low-space tests.
 
+- [ ] A copied pre-transfer installation updates through its original signed
+  feed into the Omacom candidate. Record starting and target versions, release
+  URLs and redirects, signature verification, and preserved files. Force a
+  rollback and confirm the copied installation still boots. Local candidate
+  tests do not replace checking the public URLs after publication.
 - [ ] An existing guest upgrades without replacing its OS, account, or files.
 - [ ] Interrupt the first updated boot before readiness, then relaunch. Previous
   launcher and payloads return and the existing files remain readable.

--- a/docs/V1-READINESS.md
+++ b/docs/V1-READINESS.md
@@ -4,6 +4,31 @@ The Windows app and the Mac app now live under Omacom. A stable Windows release
 still needs the checks below. A passing build does not establish hardware or
 upgrade reliability.
 
+## Official v1 checklist
+
+These items follow the Omarchy Basecamp board. Keep technical work moving while
+maintainer decisions are pending; those decisions are not prerequisites for
+code changes or hardware testing.
+
+| Board item | Current evidence and remaining work |
+| --- | --- |
+| Restore signing and release CI after the transfer | The [post-transfer signing check](https://github.com/omacom/try-omarchy-windows/actions/runs/33832168714) passed, including Authenticode and the update signing key. Still verify draft preparation and publication through the transferred repository when the candidate is ready. See [RELEASING.md](RELEASING.md). |
+| Decide official ownership of signing and hosting | Maintainer decision in #37. Keep separate from the technical work below. |
+| Validate the source-built QEMU runtime on real hardware | Record the exact archive hash and physical Windows results in #12 and #10 using [RUNTIME-VALIDATION.md](RUNTIME-VALIDATION.md). |
+| Promote the source-built QEMU runtime into production | After validation, pin the tested runtime and matching source archive in `guest-build/runtime.lock.json`, prepare a candidate, and verify its packaged runtime. Build success alone does not complete #12. |
+| Verify the first update across the repo transfer | Test a copied pre-transfer installation through the signed update path into the Omacom candidate. Check redirects, downloads, preserved files, and rollback in #14. This is separate from preview-to-stable migration. |
+| Validate full Hyper-V compatibility | Run the full launch, rendering fallback, clipboard, sharing, audio, reboot, and shutdown checks on physical Windows with full Hyper-V enabled. Record results in #4 and update the compatibility documentation. |
+| Publish v1.0 through the official sites | Prepare concise release notes and verified Windows download links. After maintainer approval and publication, check the official site links, downloaded signature, and version. Site access and publication approval remain with maintainers (#37). |
+
+## Next technical work
+
+1. Validate the source runtime on physical hardware, including full Hyper-V.
+2. Promote the exact tested archives and prepare a signed candidate.
+3. Test fresh installs, the repository-transfer update, preview-to-stable
+   migration, rollback, and data preservation.
+4. Finish the applicable release gates below and prepare the release notes and
+   official download handoff. Publish only after validation and approval.
+
 ## Merged for release testing
 
 - [#34](https://github.com/omacom/try-omarchy-windows/pull/34): stable updates,
@@ -32,14 +57,19 @@ upgrade reliability.
   backup.
 - [ ] Exercise sleep/resume, mixed-DPI resize, audio-device changes, and a long
   session. Record idle CPU and whether launch alone activates the microphone.
-- [ ] Agree release ownership, signing access and recovery, branding, download
-  location, support routing, and shared Mac/Windows behavior with maintainers (#37).
 - [ ] Update user documentation to describe the tested release, including how
   existing guests receive Omarchy OS updates separately from launcher updates.
 
 Use [TESTING.md](TESTING.md) for reports. Each gate needs evidence for the exact
 candidate version and runtime, not only an earlier preview. Keep release
 publication separate from code review and merging.
+
+## Maintainer coordination
+
+Signing ownership, key recovery, hosting, official site access, release approval,
+and support ownership are tracked in #37. Record decisions when available;
+continue implementation and validation without waiting for them. Prepare the
+release assets, notes, and download handoff within this repository first.
 
 ## Scope
 


### PR DESCRIPTION
Document runtime promotion, repository-transfer update testing, and release download verification. Add transfer update and rollback checks to the Windows test report.

Documentation only. Checked against the release workflow and test instructions.
