### PR TITLE
Verify release downloads and repository redirects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
           go-version-file: app/go.mod
           cache-dependency-path: app/go.sum
 
+      - name: Test public release verification
+        shell: pwsh
+        run: scripts/release/test-verify-public.ps1
+
       - name: Test launcher on Windows
         working-directory: app
         run: go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,7 +360,9 @@ jobs:
 
       - name: Verify public tagged assets
         shell: pwsh
-        run: scripts/release/verify-public.ps1 -Tag $env:RELEASE_TAG
+        run: |
+          scripts/release/verify-public.ps1 -Tag $env:RELEASE_TAG
+          scripts/release/verify-public.ps1 -Tag $env:RELEASE_TAG -Repository tsouth89/try-omarchy-windows
 
       - name: Promote newer releases without replacing stable with preview
         id: promote
@@ -382,4 +384,6 @@ jobs:
       - name: Verify public Latest download
         if: steps.promote.outputs.latest == 'true'
         shell: pwsh
-        run: scripts/release/verify-public.ps1 -Tag $env:RELEASE_TAG -Latest
+        run: |
+          scripts/release/verify-public.ps1 -Tag $env:RELEASE_TAG -Latest
+          scripts/release/verify-public.ps1 -Tag $env:RELEASE_TAG -Latest -Repository tsouth89/try-omarchy-windows

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -98,8 +98,10 @@ Run the `Release` workflow again with phase `publish` and the same tag. It:
 - signs current update metadata with the protected Ed25519 update key;
 - verifies Authenticode before upload;
 - publishes without changing `Latest`;
-- verifies the public tagged launcher, checksum, manifest, and guest URL;
-- marks the release `Latest`, then verifies the `latest/download` path.
+- verifies the public tagged launcher, checksum, manifest, and guest URL through
+  both the current repository and the original repository redirect;
+- marks the release `Latest`, then verifies both repositories' `latest/download`
+  paths, including the legacy and current signed update feeds.
 
 If public verification fails, the release stays published but does not replace
 the previous `Latest` release.

--- a/scripts/release/test-verify-public.ps1
+++ b/scripts/release/test-verify-public.ps1
@@ -1,0 +1,82 @@
+$ErrorActionPreference = 'Stop'
+$verifier = Join-Path $PSScriptRoot 'verify-public.ps1'
+$root = Join-Path ([System.IO.Path]::GetTempPath()) "try-omarchy-verifier-test-$([guid]::NewGuid())"
+$previousTemp = $env:RUNNER_TEMP
+New-Item -ItemType Directory -Path "$root/release", "$root/app/testdata", "$root/temp" -Force | Out-Null
+$env:RUNNER_TEMP = "$root/temp"
+Push-Location $root
+
+# Run the real verifier against deterministic downloads, including failed
+# requests that leave an older file behind unless the verifier removes it.
+function global:curl.exe {
+    $url = [string]$args[-1]
+    $global:downloadURLs.Add($url)
+    $name = ([uri]$url).AbsolutePath.Split('/')[-1]
+    $attempt = if ($url -match 'attempt=(\d+)') { [int]$Matches[1] } else { 1 }
+    $global:LASTEXITCODE = 0
+    $failure = switch ($global:downloadCase) {
+        'launcher-failure' { $name -eq 'TryOmarchy.exe' }
+        'stale-launcher' { $name -eq 'TryOmarchy.exe' -and $attempt -gt 1 }
+        'metadata-failure' { $name -eq 'update-v2.json' }
+        'signature-failure' { $name -eq 'update.json.sig' }
+        'sums-failure' { $name -eq 'SHA256SUMS' }
+        'guest-failure' { $name -eq 'rootfs.ext4.zst' }
+        default { $false }
+    }
+    if ($failure) { $global:LASTEXITCODE = 22; return }
+    if ($args -contains '--head') { return }
+    $destination = $args[[array]::IndexOf($args, '--output') + 1]
+    Copy-Item -LiteralPath "release/$name" -Destination $destination
+    if ($global:downloadCase -eq 'stale-launcher' -and $name -eq 'TryOmarchy.exe.sha256' -and $attempt -eq 1) {
+        Set-Content -LiteralPath $destination -Value ('0' * 64)
+    }
+}
+
+try {
+    Set-Content release/TryOmarchy.exe 'test launcher'
+    $hash = (Get-FileHash release/TryOmarchy.exe).Hash.ToLowerInvariant()
+    Set-Content release/TryOmarchy.exe.sha256 "$hash  TryOmarchy.exe"
+    $metadata = @{version = 'v1.0.0'; launcher = @{sha256 = $hash}} | ConvertTo-Json -Compress
+    foreach ($feed in @('update.json', 'update-v2.json')) {
+        Set-Content "release/$feed" $metadata
+        Set-Content "release/$feed.sig" 'test signature'
+    }
+    Set-Content release/SHA256SUMS 'test pinned manifest'
+    Copy-Item release/SHA256SUMS app/testdata/SHA256SUMS.v1.0.0
+
+    foreach ($case in @('success', 'launcher-failure', 'stale-launcher', 'metadata-failure', 'signature-failure', 'sums-failure', 'guest-failure', 'wrong-version')) {
+        $global:downloadCase = $case
+        $global:downloadURLs = [System.Collections.Generic.List[string]]::new()
+        if ($case -eq 'wrong-version') {
+            Set-Content release/update-v2.json ($metadata.Replace('v1.0.0', 'v2.0.0'))
+        }
+        $failureMessage = $null
+        try { & $verifier -Tag v1.0.0 -Attempts 2 -RetryDelaySeconds 0 | Out-Null }
+        catch { $failureMessage = $_.Exception.Message }
+        if ($case -eq 'success' -and $failureMessage) { throw "Success case failed: $failureMessage" }
+        if ($case -ne 'success' -and -not $failureMessage) { throw "Accepted $case" }
+        if ($case -eq 'wrong-version') {
+            Set-Content release/update-v2.json $metadata
+            if ($failureMessage -notlike '*requested version*') { throw "Wrong version failed for an unrelated reason: $failureMessage" }
+        }
+        if (Get-ChildItem "$root/temp") { throw "Temporary files remain after $case" }
+        Write-Output "ok - $case"
+    }
+
+    $global:downloadCase = 'success'
+    $global:downloadURLs.Clear()
+    & $verifier -Tag v1.0.0 -Latest -Repository tsouth89/try-omarchy-windows -Attempts 1 -RetryDelaySeconds 0 | Out-Null
+    if ($global:downloadURLs.Count -ne 6) { throw 'Latest did not check all launcher and feed assets' }
+    foreach ($url in $global:downloadURLs) {
+        if (-not $url.StartsWith('https://github.com/tsouth89/try-omarchy-windows/releases/latest/download/')) {
+            throw "Unexpected legacy Latest URL: $url"
+        }
+    }
+    Write-Output 'ok - legacy Latest feed and launcher URLs'
+} finally {
+    Pop-Location
+    $env:RUNNER_TEMP = $previousTemp
+    Remove-Item function:global:curl.exe
+    Remove-Variable downloadCase, downloadURLs -Scope Global -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $root -Recurse -Force
+}

--- a/scripts/release/verify-public.ps1
+++ b/scripts/release/verify-public.ps1
@@ -1,38 +1,48 @@
 param(
     [Parameter(Mandatory = $true)][string]$Tag,
-    [switch]$Latest
+    [switch]$Latest,
+    [ValidateSet('omacom/try-omarchy-windows', 'tsouth89/try-omarchy-windows')]
+    [string]$Repository = 'omacom/try-omarchy-windows',
+    [ValidateRange(1, 18)][int]$Attempts = 18,
+    [ValidateRange(0, 60)][int]$RetryDelaySeconds = 10
 )
 
 $ErrorActionPreference = 'Stop'
-$repository = 'omacom/try-omarchy-windows'
 $releasePath = if ($Latest) { 'latest/download' } else { "download/$Tag" }
 $base = "https://github.com/$repository/releases/$releasePath"
 $work = Join-Path $env:RUNNER_TEMP "try-omarchy-public-$([guid]::NewGuid())"
 New-Item -ItemType Directory -Path $work | Out-Null
 
+function Get-PublicAsset([string]$Name, [int]$Attempt) {
+    $destination = Join-Path $work $Name
+    Remove-Item -LiteralPath $destination -Force -ErrorAction SilentlyContinue
+    curl.exe --fail --silent --show-error --location --connect-timeout 20 --max-time 120 --output $destination "$base/$($Name)?attempt=$Attempt"
+    return ($LASTEXITCODE -eq 0 -and (Test-Path -LiteralPath $destination -PathType Leaf))
+}
+
 try {
     $matched = $false
-    for ($attempt = 1; $attempt -le 18; $attempt++) {
-        curl.exe --fail --silent --show-error --location --output "$work\TryOmarchy.exe" "$base/TryOmarchy.exe?attempt=$attempt"
-        curl.exe --fail --silent --show-error --location --output "$work\TryOmarchy.exe.sha256" "$base/TryOmarchy.exe.sha256?attempt=$attempt"
-        $expected = ((Get-Content "$work\TryOmarchy.exe.sha256" -Raw).Trim() -split '\s+')[0]
-        $actual = (Get-FileHash "$work\TryOmarchy.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
-        if ($actual -eq $expected) {
-            $matched = $true
-            break
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        $launcherOK = Get-PublicAsset 'TryOmarchy.exe' $attempt
+        $checksumOK = Get-PublicAsset 'TryOmarchy.exe.sha256' $attempt
+        if ($launcherOK -and $checksumOK) {
+            $expected = ((Get-Content "$work/TryOmarchy.exe.sha256" -Raw).Trim() -split '\s+')[0]
+            $actual = (Get-FileHash "$work/TryOmarchy.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
+            if ($expected -cmatch '^[0-9a-f]{64}$' -and $actual -eq $expected) {
+                $matched = $true
+                break
+            }
         }
-        Start-Sleep -Seconds 10
+        Start-Sleep -Seconds $RetryDelaySeconds
     }
     if (-not $matched) { throw "$releasePath kept serving a mismatched launcher and checksum" }
 
     foreach ($feed in @('update.json', 'update-v2.json')) {
         $updateMatched = $false
         if (-not (Test-Path "release/$feed")) { throw "Missing local $feed" }
-        for ($attempt = 1; $attempt -le 18; $attempt++) {
-            curl.exe --fail --silent --show-error --location --output "$work\$feed" "$base/$($feed)?attempt=$attempt"
-            $metadataOK = $LASTEXITCODE -eq 0
-            curl.exe --fail --silent --show-error --location --output "$work\$feed.sig" "$base/$($feed).sig?attempt=$attempt"
-            $signatureOK = $LASTEXITCODE -eq 0
+        for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+            $metadataOK = Get-PublicAsset $feed $attempt
+            $signatureOK = Get-PublicAsset "$feed.sig" $attempt
             if ($metadataOK -and $signatureOK) {
                 $manifestMatches = (Get-FileHash "release/$feed").Hash -eq (Get-FileHash "$work\$feed").Hash
                 $signatureMatches = (Get-FileHash "release/$feed.sig").Hash -eq (Get-FileHash "$work\$feed.sig").Hash
@@ -41,7 +51,7 @@ try {
                     break
                 }
             }
-            Start-Sleep -Seconds 10
+            Start-Sleep -Seconds $RetryDelaySeconds
         }
         if (-not $updateMatched) { throw "$releasePath kept serving stale $feed metadata" }
     }
@@ -51,16 +61,19 @@ try {
     }
 
     if (-not $Latest) {
-        curl.exe --fail --silent --show-error --location --output "$work\SHA256SUMS" "$base/SHA256SUMS"
+        if (-not (Get-PublicAsset 'SHA256SUMS' 1)) {
+            throw 'Could not download public SHA256SUMS'
+        }
         $fixture = "app/testdata/SHA256SUMS.$Tag"
         if ((Get-FileHash $fixture -Algorithm SHA256).Hash -ne
             (Get-FileHash "$work\SHA256SUMS" -Algorithm SHA256).Hash) {
             throw 'Public SHA256SUMS does not match the source pin'
         }
-        curl.exe --fail --silent --show-error --location --head "$base/rootfs.ext4.zst" | Out-Null
+        curl.exe --fail --silent --show-error --location --connect-timeout 20 --max-time 120 --head "$base/rootfs.ext4.zst" | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw 'Public guest image is unavailable' }
     }
 } finally {
     Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue
 }
 
-Write-Output "Verified public $releasePath assets."
+Write-Output "Verified public $Repository $releasePath assets."


### PR DESCRIPTION
Release checks now reject failed downloads even when an older file is present, and fail if the guest image URL is unavailable. Verify the original repository redirects alongside the current download URLs so existing installations stay covered.

Tested: nine PowerShell cases covering successful downloads, failures, stale files, version mismatch, and legacy URLs; ten release-helper tests. The PowerShell checks also run in Windows CI.
