### PR TITLE
Add command-line VM backup and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ out of this core Windows change so they can be reviewed separately.
 
 Or skip the app and drive QEMU from PowerShell: `scripts\bootstrap.ps1` then `scripts\launch-omarchy.ps1` (elevated).
 
+## VM backups
+
+Development builds support `-backup` for stopped standard installs and `-restore`
+into a separate data folder. See the [backup guide](docs/BACKUP.md) for usage,
+storage requirements, and current limitations.
+
 ## FAQ
 
 ### Isn't this just QEMU in disguise?

--- a/app/backup.go
+++ b/app/backup.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+const backupManifestName = "backup.json"
+const backupMaxFiles = 10000
+const backupMaxBytes int64 = 2 << 40
+
+type backupEntry struct {
+	Name   string `json:"name"`
+	Size   int64  `json:"size"`
+	SHA256 string `json:"sha256"`
+}
+type backupManifest struct {
+	Version int           `json:"version"`
+	Files   []backupEntry `json:"files"`
+}
+
+func backupNameAllowed(name string) bool {
+	if name != path.Clean(name) || strings.ContainsAny(name, "\\:") || strings.HasPrefix(name, "/") {
+		return false
+	}
+	for _, part := range strings.Split(name, "/") {
+		if part == "." || part == ".." || strings.TrimRight(part, " .") != part {
+			return false
+		}
+		base := strings.ToUpper(strings.SplitN(part, ".", 2)[0])
+		if base == "CON" || base == "PRN" || base == "AUX" || base == "NUL" || (len(base) == 4 && (strings.HasPrefix(base, "COM") || strings.HasPrefix(base, "LPT")) && base[3] >= '0' && base[3] <= '9') {
+			return false
+		}
+	}
+	return name == "vm/disk.raw" || name == "settings.json" || name == storageSettingsFilename || strings.HasPrefix(name, "guest/") || strings.HasPrefix(name, "runtime/")
+}
+
+func requiredBackupFiles(files map[string]bool) error {
+	for _, name := range []string{"vm/disk.raw", "guest/build-spec.json", "guest/rootfs.ext4", "guest/vmlinuz-linux", "guest/initramfs-linux.img"} {
+		if !files[name] {
+			return fmt.Errorf("backup is missing %s", name)
+		}
+	}
+	return nil
+}
+
+// Backup and restore are called while the launcher holds its lifecycle lock.
+// Holding the disk itself exclusively also catches an orphaned QEMU process.
+func writeVMBackup(dir, destination string) error {
+	root, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return err
+	}
+	parent, err := filepath.EvalSymlinks(filepath.Dir(destination))
+	if err != nil {
+		return err
+	}
+	root, err = filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	parent, err = filepath.Abs(parent)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(root, parent)
+	if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("save the backup outside the Try Omarchy data folder")
+	}
+
+	for _, name := range []string{payloadUpdateStateFilename, updateStateFilename} {
+		if _, err := os.Lstat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			return fmt.Errorf("finish the pending update before backing up")
+		}
+	}
+	disk, err := openBackupDisk(filepath.Join(dir, "vm", "disk.raw"))
+	if err != nil {
+		return fmt.Errorf("close Try Omarchy before backing up: %w", err)
+	}
+	defer disk.Close()
+	var entries []backupEntry
+	seen := map[string]bool{}
+	var total int64
+	for _, root := range []string{"guest", "runtime", "vm/disk.raw", "settings.json", storageSettingsFilename} {
+		full := filepath.Join(dir, filepath.FromSlash(root))
+		if _, err := os.Lstat(full); os.IsNotExist(err) {
+			continue
+		}
+		err := filepath.WalkDir(full, func(name string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				return nil
+			}
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			rel, err := filepath.Rel(dir, name)
+			if err != nil {
+				return err
+			}
+			rel = filepath.ToSlash(rel)
+			if !info.Mode().IsRegular() || !backupNameAllowed(rel) {
+				return fmt.Errorf("cannot back up unsupported file %s", rel)
+			}
+			if len(entries) >= backupMaxFiles || info.Size() > backupMaxBytes-total {
+				return fmt.Errorf("backup exceeds supported size")
+			}
+			total += info.Size()
+			entries = append(entries, backupEntry{Name: rel, Size: info.Size()})
+			seen[rel] = true
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	if err := requiredBackupFiles(seen); err != nil {
+		return err
+	}
+	// Budget uncompressed size so success does not depend on compressibility.
+	if err := requireDiskSpace(filepath.Dir(destination), total+diskSpaceReserve); err != nil {
+		return err
+	}
+	if _, err := os.Lstat(destination); !os.IsNotExist(err) {
+		return fmt.Errorf("choose a new backup filename")
+	}
+	f, err := os.CreateTemp(filepath.Dir(destination), ".try-omarchy-backup-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+	zw := zip.NewWriter(f)
+	for i := range entries {
+		entry := &entries[i]
+		source := disk
+		if entry.Name != "vm/disk.raw" {
+			source, err = os.Open(filepath.Join(dir, filepath.FromSlash(entry.Name)))
+			if err != nil {
+				zw.Close()
+				return err
+			}
+		}
+		header := &zip.FileHeader{Name: entry.Name, Method: zip.Deflate}
+		header.SetMode(0600)
+		writer, e := zw.CreateHeader(header)
+		h := sha256.New()
+		var n int64
+		if e == nil {
+			n, e = io.Copy(io.MultiWriter(writer, h), setupReader{io.LimitReader(source, entry.Size+1)})
+		}
+		if source != disk {
+			source.Close()
+		}
+		if e != nil {
+			zw.Close()
+			return e
+		}
+		if n != entry.Size {
+			zw.Close()
+			return fmt.Errorf("%s changed while backing up", entry.Name)
+		}
+		entry.SHA256 = hex.EncodeToString(h.Sum(nil))
+	}
+	writer, err := zw.Create(backupManifestName)
+	if err != nil {
+		zw.Close()
+		return err
+	}
+	if err = json.NewEncoder(writer).Encode(backupManifest{Version: 1, Files: entries}); err != nil {
+		zw.Close()
+		return err
+	}
+	if err = zw.Close(); err != nil {
+		return err
+	}
+	if err = f.Sync(); err != nil {
+		return err
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+	// A hard link publishes without replacing a backup created concurrently.
+	if err = os.Link(f.Name(), destination); err != nil {
+		return fmt.Errorf("publishing backup (use an NTFS or ReFS destination): %w", err)
+	}
+	return nil
+}
+
+func readVMBackup(z *zip.ReadCloser) (backupManifest, map[string]*zip.File, error) {
+	var manifest backupManifest
+	files := map[string]*zip.File{}
+	names := map[string]bool{}
+	if len(z.File) > backupMaxFiles+1 {
+		return manifest, nil, fmt.Errorf("too many backup files")
+	}
+	for _, f := range z.File {
+		key := strings.ToLower(f.Name)
+		if names[key] || !f.Mode().IsRegular() || (f.Name != backupManifestName && !backupNameAllowed(f.Name)) {
+			return manifest, nil, fmt.Errorf("unsupported or duplicate backup file %q", f.Name)
+		}
+		names[key] = true
+		files[f.Name] = f
+	}
+	metadata := files[backupManifestName]
+	if metadata == nil || metadata.UncompressedSize64 > 4<<20 {
+		return manifest, nil, fmt.Errorf("missing or oversized backup manifest")
+	}
+	r, err := metadata.Open()
+	if err != nil {
+		return manifest, nil, err
+	}
+	defer r.Close()
+	dec := json.NewDecoder(io.LimitReader(r, (4<<20)+1))
+	dec.DisallowUnknownFields()
+	if err = dec.Decode(&manifest); err != nil {
+		return manifest, nil, err
+	}
+	if dec.Decode(&struct{}{}) != io.EOF || manifest.Version != 1 || len(manifest.Files) != len(files)-1 {
+		return manifest, nil, fmt.Errorf("unsupported backup manifest")
+	}
+	seen := map[string]bool{}
+	var total int64
+	for _, entry := range manifest.Files {
+		f := files[entry.Name]
+		if !backupNameAllowed(entry.Name) || seen[entry.Name] || f == nil || entry.Size < 0 || entry.Size > backupMaxBytes-total || uint64(entry.Size) != f.UncompressedSize64 || !validSHA256(entry.SHA256) {
+			return manifest, nil, fmt.Errorf("invalid backup entry %q", entry.Name)
+		}
+		seen[entry.Name] = true
+		total += entry.Size
+	}
+	return manifest, files, requiredBackupFiles(seen)
+}
+
+type backupSparseWriter struct{ file *os.File }
+
+func (w backupSparseWriter) Write(p []byte) (int, error) {
+	zero := true
+	for _, b := range p {
+		if b != 0 {
+			zero = false
+			break
+		}
+	}
+	if zero {
+		_, err := w.file.Seek(int64(len(p)), io.SeekCurrent)
+		if err != nil {
+			return 0, err
+		}
+		return len(p), nil
+	}
+	return w.file.Write(p)
+}
+
+// Restore only publishes into a new directory. Existing installations are never
+// renamed or deleted, including when validation, copying, or publication fails.
+func restoreVMBackup(source, destination string) error {
+	if _, err := os.Lstat(destination); !os.IsNotExist(err) {
+		return fmt.Errorf("restore requires a new data folder; the existing folder was not changed")
+	}
+	z, err := zip.OpenReader(source)
+	if err != nil {
+		return err
+	}
+	defer z.Close()
+	manifest, files, err := readVMBackup(z)
+	if err != nil {
+		return err
+	}
+	var total int64
+	for _, entry := range manifest.Files {
+		total += entry.Size
+	}
+	if err = requireDiskSpace(filepath.Dir(destination), total+diskSpaceReserve); err != nil {
+		return err
+	}
+	staging, err := os.MkdirTemp(filepath.Dir(destination), ".try-omarchy-restore-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(staging)
+	for _, entry := range manifest.Files {
+		target := filepath.Join(staging, filepath.FromSlash(entry.Name))
+		if err = os.MkdirAll(filepath.Dir(target), 0700); err != nil {
+			return err
+		}
+		if err = restoreBackupFile(files[entry.Name], target, entry); err != nil {
+			return err
+		}
+	}
+	// The main launcher uses Windows, where Rename cannot replace a directory.
+	if _, err = os.Lstat(destination); !os.IsNotExist(err) {
+		return fmt.Errorf("restore destination appeared during copying")
+	}
+	return os.Rename(staging, destination)
+}
+
+func restoreBackupFile(z *zip.File, target string, entry backupEntry) error {
+	r, err := z.Open()
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	f, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err = setSparse(f); err != nil {
+		return fmt.Errorf("restore needs sparse-file support: %w", err)
+	}
+	h := sha256.New()
+	n, err := io.Copy(io.MultiWriter(backupSparseWriter{f}, h), setupReader{io.LimitReader(r, entry.Size+1)})
+	if err != nil {
+		return err
+	}
+	if n != entry.Size || hex.EncodeToString(h.Sum(nil)) != entry.SHA256 {
+		return fmt.Errorf("backup checksum mismatch for %s", entry.Name)
+	}
+	if err = f.Truncate(n); err != nil {
+		return err
+	}
+	if err = f.Sync(); err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/app/backup_nonwindows.go
+++ b/app/backup_nonwindows.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func openBackupDisk(path string) (*os.File, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	if err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return f, nil
+}

--- a/app/backup_test.go
+++ b/app/backup_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func backupFixture(t *testing.T) (string, string) {
+	t.Helper()
+	configureSetupCancellation(false)
+	root := t.TempDir()
+	dir := filepath.Join(root, "original")
+	for _, name := range []string{"vm/disk.raw", "guest/build-spec.json", "guest/rootfs.ext4", "guest/vmlinuz-linux", "guest/initramfs-linux.img", "runtime/bin/qemu.exe", "settings.json", storageSettingsFilename} {
+		target := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(target), 0700); err != nil {
+			t.Fatal(err)
+		}
+		data := []byte("fixture " + name)
+		if name == "vm/disk.raw" {
+			data = append(data, make([]byte, 2<<20)...)
+		}
+		if err := os.WriteFile(target, data, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir, filepath.Join(root, "backup.zip")
+}
+
+func TestVMBackupRoundTripPreservesOriginal(t *testing.T) {
+	dir, archive := backupFixture(t)
+	if err := writeVMBackup(dir, archive); err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(filepath.Dir(dir), "restored")
+	if err := restoreVMBackup(archive, destination); err != nil {
+		t.Fatal(err)
+	}
+	err := filepath.WalkDir(dir, func(name string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(dir, name)
+		want, _ := os.ReadFile(name)
+		got, e := os.ReadFile(filepath.Join(destination, rel))
+		if e != nil {
+			return e
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("restored %s differs", rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := restoreVMBackup(archive, dir); err == nil {
+		t.Fatal("replaced existing installation")
+	}
+	original, _ := os.ReadFile(archive)
+	if err := writeVMBackup(dir, archive); err == nil {
+		t.Fatal("replaced existing backup")
+	}
+	after, _ := os.ReadFile(archive)
+	if !bytes.Equal(original, after) {
+		t.Fatal("existing backup changed")
+	}
+}
+
+func TestVMBackupRejectsLockedDiskAndPendingUpdate(t *testing.T) {
+	dir, archive := backupFixture(t)
+	lock, err := openBackupDisk(filepath.Join(dir, "vm", "disk.raw"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeVMBackup(dir, archive); err == nil {
+		lock.Close()
+		t.Fatal("backed up locked disk")
+	}
+	lock.Close()
+	if err := os.WriteFile(filepath.Join(dir, payloadUpdateStateFilename), []byte("pending"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeVMBackup(dir, archive); err == nil {
+		t.Fatal("backed up pending update")
+	}
+	if _, err := os.Stat(archive); !os.IsNotExist(err) {
+		t.Fatal("published failed backup")
+	}
+}
+
+func TestVMBackupSpaceAndCancellationLeaveNoOutput(t *testing.T) {
+	dir, archive := backupFixture(t)
+	previous := diskFreeBytes
+	t.Cleanup(func() { diskFreeBytes = previous; configureSetupCancellation(false) })
+	diskFreeBytes = func(string) (int64, error) { return 0, nil }
+	if err := writeVMBackup(dir, archive); !errors.Is(err, errInsufficientDiskSpace) {
+		t.Fatalf("space failure: %v", err)
+	}
+	diskFreeBytes = previous
+	requestSetupCancel()
+	if err := writeVMBackup(dir, archive); !errors.Is(err, errSetupCancelled) {
+		t.Fatalf("cancel failure: %v", err)
+	}
+	if _, err := os.Stat(archive); !os.IsNotExist(err) {
+		t.Fatal("published cancelled backup")
+	}
+	matches, _ := filepath.Glob(filepath.Join(filepath.Dir(dir), ".try-omarchy-*"))
+	if len(matches) != 0 {
+		t.Fatalf("left temporary files: %v", matches)
+	}
+}
+
+func rewriteBackup(t *testing.T, source, destination string, mutate func(string, []byte) (string, []byte)) {
+	t.Helper()
+	r, err := zip.OpenReader(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	out, err := os.Create(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := zip.NewWriter(out)
+	for _, f := range r.File {
+		in, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(in)
+		in.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		name, data := mutate(f.Name, data)
+		entry, err := w.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = entry.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err = w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err = out.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVMRestoreRejectsDamagedBackupWithoutPublishing(t *testing.T) {
+	dir, archive := backupFixture(t)
+	if err := writeVMBackup(dir, archive); err != nil {
+		t.Fatal(err)
+	}
+	damaged := filepath.Join(filepath.Dir(dir), "damaged.zip")
+	rewriteBackup(t, archive, damaged, func(name string, data []byte) (string, []byte) {
+		if name == "vm/disk.raw" {
+			data[0] ^= 1
+		}
+		return name, data
+	})
+	destination := filepath.Join(filepath.Dir(dir), "restored")
+	if err := restoreVMBackup(damaged, destination); err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("expected checksum failure, got %v", err)
+	}
+	if _, err := os.Stat(destination); !os.IsNotExist(err) {
+		t.Fatal("published damaged restore")
+	}
+	matches, _ := filepath.Glob(filepath.Join(filepath.Dir(dir), ".try-omarchy-restore-*"))
+	if len(matches) != 0 {
+		t.Fatal("left failed staging directory")
+	}
+}
+
+func TestVMRestoreSpaceAndCancellation(t *testing.T) {
+	dir, archive := backupFixture(t)
+	if err := writeVMBackup(dir, archive); err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(filepath.Dir(dir), "restored")
+	previous := diskFreeBytes
+	t.Cleanup(func() { diskFreeBytes = previous; configureSetupCancellation(false) })
+	diskFreeBytes = func(string) (int64, error) { return 0, nil }
+	if err := restoreVMBackup(archive, destination); !errors.Is(err, errInsufficientDiskSpace) {
+		t.Fatalf("space failure: %v", err)
+	}
+	diskFreeBytes = previous
+	requestSetupCancel()
+	if err := restoreVMBackup(archive, destination); !errors.Is(err, errSetupCancelled) {
+		t.Fatalf("cancel failure: %v", err)
+	}
+	if _, err := os.Stat(destination); !os.IsNotExist(err) {
+		t.Fatal("published failed restore")
+	}
+}
+
+func TestVMBackupNamesAndDestination(t *testing.T) {
+	for _, name := range []string{"../disk.raw", "guest/../settings.json", "guest/CON", "runtime/bin/file:stream", "guest/trailing.", "vm/disk.qcow2", "shared/personal.txt"} {
+		if backupNameAllowed(name) {
+			t.Errorf("accepted unsupported name %q", name)
+		}
+	}
+	dir, _ := backupFixture(t)
+	if err := writeVMBackup(dir, filepath.Join(dir, "guest", "backup.zip")); err == nil {
+		t.Fatal("accepted backup inside data folder")
+	}
+}
+
+func TestVMRestoreRejectsIncompleteAndUnsupportedArchives(t *testing.T) {
+	dir, archive := backupFixture(t)
+	if err := writeVMBackup(dir, archive); err != nil {
+		t.Fatal(err)
+	}
+	for _, kind := range []string{"unsupported-version", "unexpected-file", "duplicate-case"} {
+		t.Run(kind, func(t *testing.T) {
+			changed := filepath.Join(filepath.Dir(dir), kind+".zip")
+			rewriteBackup(t, archive, changed, func(name string, data []byte) (string, []byte) {
+				if kind == "unsupported-version" && name == backupManifestName {
+					data = bytes.Replace(data, []byte(`"version":1`), []byte(`"version":2`), 1)
+				}
+				if kind == "unexpected-file" && name == "vm/disk.raw" {
+					name = "other/disk.raw"
+				}
+				if kind == "duplicate-case" && name == storageSettingsFilename {
+					name = "SETTINGS.JSON"
+				}
+				return name, data
+			})
+			destination := filepath.Join(filepath.Dir(dir), kind)
+			if err := restoreVMBackup(changed, destination); err == nil {
+				t.Fatal("accepted invalid archive")
+			}
+			if _, err := os.Stat(destination); !os.IsNotExist(err) {
+				t.Fatal("published invalid archive")
+			}
+		})
+	}
+	if err := os.Remove(filepath.Join(dir, "guest", "vmlinuz-linux")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeVMBackup(dir, archive+".incomplete"); err == nil {
+		t.Fatal("backed up missing kernel")
+	}
+}

--- a/app/backup_windows.go
+++ b/app/backup_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func openBackupDisk(path string) (*os.File, error) {
+	name, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := syscall.CreateFile(name, syscall.GENERIC_READ, 0, nil, syscall.OPEN_EXISTING, syscall.FILE_ATTRIBUTE_NORMAL, 0)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(handle), path), nil
+}

--- a/app/main.go
+++ b/app/main.go
@@ -143,6 +143,8 @@ func main() {
 	var forwards forwardList
 	flag.Var(&forwards, "forward", "forward a Windows loopback port into Omarchy, as tcp:2222:22 or 8080:80 (repeatable)")
 	sshPort := flag.Int("ssh", 0, "forward this Windows loopback port to Omarchy's sshd and start sshd for the session")
+	backupPath := flag.String("backup", "", "back up a stopped standard VM to a new ZIP file, then exit")
+	restorePath := flag.String("restore", "", "restore a trusted backup into a new folder selected with -dir, then exit")
 	openSettings := flag.Bool("settings", false, "open the settings window, then exit")
 	diagnostics := flag.Bool("diagnostics", false, "write a zip of logs, settings, and machine facts for a bug report, then exit")
 	sshKeyPath := flag.String("ssh-key", "", "public key to authorize for the Omarchy account (default: your ~/.ssh/id_*.pub when -ssh is used)")
@@ -162,8 +164,18 @@ func main() {
 	updateWaitPID := flag.Int("update-wait-pid", 0, "internal: process to wait for before replacing the launcher")
 	updateRestartArgs := flag.String("update-restart-args", "", "internal: encoded launcher restart arguments")
 	flag.Parse()
+	maintenance := *backupPath != "" || *restorePath != ""
+	if maintenance && (*backupPath != "" && *restorePath != "" || cfg.portable || cfg.fresh || *openSettings || *diagnostics || *enableWhp || *applyLauncherUpdateFlag || *applyLauncherRollbackFlag) {
+		fatal("Use either -backup or -restore on a stopped standard install, without other maintenance options.")
+	}
 	explicitFlags := map[string]bool{}
 	flag.Visit(func(f *flag.Flag) { explicitFlags[f.Name] = true })
+	if explicitFlags["backup"] && strings.TrimSpace(*backupPath) == "" || explicitFlags["restore"] && strings.TrimSpace(*restorePath) == "" {
+		fatal("Provide a backup filename with -backup or -restore.")
+	}
+	if *restorePath != "" && !explicitFlags["dir"] {
+		fatal("Use -dir with a new data folder when restoring. Existing installations are never replaced.")
+	}
 	if strings.TrimSpace(*runtimeRelease) == "" {
 		*runtimeRelease = *release
 	}
@@ -195,7 +207,7 @@ func main() {
 		// not travel to another PC with the USB.
 		cfg.hostDir = filepath.Join(os.Getenv("LOCALAPPDATA"), "TryOmarchy", "portable-host")
 	} else {
-		promptForLocation := !*diagnostics && !*applyLauncherUpdateFlag && !*applyLauncherRollbackFlag
+		promptForLocation := !maintenance && !*diagnostics && !*applyLauncherUpdateFlag && !*applyLauncherRollbackFlag
 		selected, proceed, err := resolveStandardDataDirectory(
 			defaultDir, cfg.dir, explicitFlags["dir"], promptForLocation, chooseFirstRunDataDirectory,
 		)
@@ -225,7 +237,7 @@ func main() {
 		}
 		// Settings and diagnostics may be opened from the running app's tray.
 		// They must not inspect or roll back an update owned by that parent.
-		if !*openSettings && !*diagnostics {
+		if !maintenance && !*openSettings && !*diagnostics {
 			restartArgs, err := encodeRestartArgs(os.Args[1:])
 			if err != nil {
 				fatal("Could not preserve launcher arguments for updates: %v", err)
@@ -236,6 +248,28 @@ func main() {
 				return
 			}
 		}
+	}
+
+	if maintenance {
+		var err error
+		if *backupPath != "" {
+			getUI().setStatus("Creating VM backup. This may take a while...")
+			err = writeVMBackup(cfg.dir, *backupPath)
+		} else {
+			getUI().setStatus("Verifying and restoring VM backup...")
+			err = restoreVMBackup(*restorePath, cfg.dir)
+		}
+		uiDone()
+		if err != nil {
+			errorBox("Try Omarchy could not finish the backup or restore.\n\n" + err.Error())
+			os.Exit(1)
+		}
+		if *backupPath != "" {
+			infoBox("Backup saved to:\n\n" + *backupPath + "\n\nIt contains your guest files and settings. Keep it private. Shared Windows folders are not included.")
+		} else {
+			infoBox("Backup restored to:\n\n" + cfg.dir + "\n\nStart Try Omarchy with -dir pointing to this folder. Your original installation was not changed.")
+		}
+		return
 	}
 
 	// Runs before settings load on purpose: a damaged settings.json is one of

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,0 +1,67 @@
+# VM backup and restore
+
+The development build supports full backups of stopped standard installs.
+Portable installs are not supported yet. These commands are separate from
+[configuration export](MIGRATION.md), which transfers your setup to a physical
+Omarchy installation.
+
+## Create a backup
+
+Shut down Omarchy and close the launcher first. From PowerShell:
+
+```powershell
+.\TryOmarchy.exe -backup "D:\Backups\omarchy.zip"
+```
+
+The destination folder must already exist on an NTFS or ReFS drive, outside the
+Try Omarchy data folder. Choose a new filename; an existing backup is never
+overwritten. Add `-dir "D:\TryOmarchy"` if you normally use an explicit data path.
+
+The ZIP includes the writable disk, factory image, matching kernel and initramfs,
+bundled runtime when present, and launcher settings. Shared Windows folders,
+external QEMU installations, logs, and the launcher executable are not included.
+Keep a copy of the launcher used to create the backup.
+
+A backup contains personal guest files, including any credentials stored in the
+guest. It is not encrypted. Store it privately and restore only backups you trust.
+
+Backup refuses a locked disk or a pending update. Finish the update and shut down
+normally before trying again. Each archived file has a SHA-256 checksum that is
+verified during restore. The ZIP appears at the chosen filename only when the
+backup finishes.
+
+## Restore to a separate folder
+
+Close Try Omarchy, then choose a folder that does not exist. Its parent must
+already exist on an NTFS or ReFS drive:
+
+```powershell
+.\TryOmarchy.exe -restore "D:\Backups\omarchy.zip" -dir "D:\OmarchyRestored"
+```
+
+Restore checks and extracts files into a temporary folder before publishing the
+new data folder. An error or cancellation leaves the existing installation and
+backup unchanged. It never replaces an existing data folder.
+
+Start the restored copy explicitly:
+
+```powershell
+.\TryOmarchy.exe -dir "D:\OmarchyRestored"
+```
+
+This does not change the default installation location or existing shortcuts.
+Settings may reference shared folders or SSH public keys on the original PC;
+review them before starting a restored copy on another machine.
+
+## Space and validation
+
+Both operations conservatively require free space for the full logical size of
+all included files, plus 1 GiB. Compression and sparse files can reduce actual
+usage, but are not counted on for the space check. Large disks can take a while
+to read even when mostly empty.
+
+Automated tests cover copying, checksums, cancellation, disk locking, low space,
+and preservation of existing folders. A restored guest still needs a Windows
+boot test before release. Keep the original installation until you have checked
+the restored copy. A Settings workflow and backup-before-reset controls remain
+planned in #36.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -24,6 +24,6 @@ Try Omarchy runs the full x86_64 Arch Linux environment used by Omarchy. It is n
 - Text clipboard sharing works in both directions. File clipboard and drag and
   drop are not implemented yet; use the shared folder for files.
 - The launcher boots its pinned kernel and initramfs from the release image. Ordinary package installation is supported, but replacing the guest kernel independently can leave it out of sync with those boot files.
-- Configuration export and restore are available through `try-omarchy-export`; see [the migration guide](MIGRATION.md). Full VM backups and snapshots are not built in yet. Back up important work outside the guest.
+- Configuration export and restore are available through `try-omarchy-export`; see [the migration guide](MIGRATION.md). Development builds also support [stopped-VM backup and restore](BACKUP.md) through command-line options. Snapshots and backup controls in Settings are not available yet.
 
 Compatibility varies with Windows, CPU, GPU, and driver combinations. When reporting a problem, include those details and whether Try Omarchy selected GPU or CPU rendering.


### PR DESCRIPTION
Add `-backup` for stopped standard installs and `-restore` into a new data folder. Backups include the guest disk, boot files, bundled runtime, and settings, with per-file checksums verified during restore. Existing installations and backups are never replaced.

Tested: fixture round trips, disk locking, cancellation, low space, damaged archives, and existing-file preservation; Go race tests, vet, and Windows build.

Part of #36. Settings controls, backup before reset, and a restored-guest boot check remain pending.
