### PR TITLE
Decode settings directly from byte buffers

### DIFF
--- a/app/settings.go
+++ b/app/settings.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -75,7 +76,7 @@ func loadSettings(path string) (settings, error) {
 	if err != nil {
 		return s, err
 	}
-	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&s); err != nil {
 		return s, fmt.Errorf("%s: %v", path, err)

--- a/app/storage.go
+++ b/app/storage.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -57,7 +58,7 @@ func loadStorageSettings(dir string) (storageSettings, error) {
 		return defaults, fmt.Errorf("storage preferences are too large")
 	}
 	var settings storageSettings
-	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&settings); err != nil {
 		return defaults, err


### PR DESCRIPTION
Read settings and storage JSON directly from byte buffers, avoiding an unnecessary conversion to string. Parsing and validation stay the same.

Checked against current master with Go race tests, vet, and a Windows build.
