### PR TITLE
Add recovery controls and preserve disks during reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,9 @@ Or skip the app and drive QEMU from PowerShell: `scripts\bootstrap.ps1` then `sc
 
 ## VM backups
 
-Development builds support `-backup` for stopped standard installs and `-restore`
-into a separate data folder. See the [backup guide](docs/BACKUP.md) for usage,
+Development builds include backup, restore, and reset controls in Settings for
+stopped standard installs. Restore creates a separate copy. Command-line options
+are also available. See the [backup guide](docs/BACKUP.md) for usage,
 storage requirements, and current limitations.
 
 ## FAQ

--- a/app/backup.go
+++ b/app/backup.go
@@ -55,6 +55,10 @@ func requiredBackupFiles(files map[string]bool) error {
 // Backup and restore are called while the launcher holds its lifecycle lock.
 // Holding the disk itself exclusively also catches an orphaned QEMU process.
 func writeVMBackup(dir, destination string) error {
+	return writeVMBackupProgress(dir, destination, nil)
+}
+
+func writeVMBackupProgress(dir, destination string, report backupProgress) error {
 	root, err := filepath.EvalSymlinks(dir)
 	if err != nil {
 		return err
@@ -142,6 +146,7 @@ func writeVMBackup(dir, destination string) error {
 	defer os.Remove(f.Name())
 	defer f.Close()
 	zw := zip.NewWriter(f)
+	var processed int64
 	for i := range entries {
 		entry := &entries[i]
 		source := disk
@@ -158,7 +163,7 @@ func writeVMBackup(dir, destination string) error {
 		h := sha256.New()
 		var n int64
 		if e == nil {
-			n, e = io.Copy(io.MultiWriter(writer, h), setupReader{io.LimitReader(source, entry.Size+1)})
+			n, e = io.Copy(io.MultiWriter(writer, h), setupReader{&backupProgressReader{source: io.LimitReader(source, entry.Size+1), processed: &processed, total: total, name: entry.Name, report: report}})
 		}
 		if source != disk {
 			source.Close()
@@ -266,6 +271,10 @@ func (w backupSparseWriter) Write(p []byte) (int, error) {
 // Restore only publishes into a new directory. Existing installations are never
 // renamed or deleted, including when validation, copying, or publication fails.
 func restoreVMBackup(source, destination string) error {
+	return restoreVMBackupProgress(source, destination, nil)
+}
+
+func restoreVMBackupProgress(source, destination string, report backupProgress) error {
 	if _, err := os.Lstat(destination); !os.IsNotExist(err) {
 		return fmt.Errorf("restore requires a new data folder; the existing folder was not changed")
 	}
@@ -290,12 +299,13 @@ func restoreVMBackup(source, destination string) error {
 		return err
 	}
 	defer os.RemoveAll(staging)
+	var processed int64
 	for _, entry := range manifest.Files {
 		target := filepath.Join(staging, filepath.FromSlash(entry.Name))
 		if err = os.MkdirAll(filepath.Dir(target), 0700); err != nil {
 			return err
 		}
-		if err = restoreBackupFile(files[entry.Name], target, entry); err != nil {
+		if err = restoreBackupFile(files[entry.Name], target, entry, &processed, total, report); err != nil {
 			return err
 		}
 	}
@@ -306,7 +316,7 @@ func restoreVMBackup(source, destination string) error {
 	return os.Rename(staging, destination)
 }
 
-func restoreBackupFile(z *zip.File, target string, entry backupEntry) error {
+func restoreBackupFile(z *zip.File, target string, entry backupEntry, processed *int64, total int64, report backupProgress) error {
 	r, err := z.Open()
 	if err != nil {
 		return err
@@ -321,7 +331,7 @@ func restoreBackupFile(z *zip.File, target string, entry backupEntry) error {
 		return fmt.Errorf("restore needs sparse-file support: %w", err)
 	}
 	h := sha256.New()
-	n, err := io.Copy(io.MultiWriter(backupSparseWriter{f}, h), setupReader{io.LimitReader(r, entry.Size+1)})
+	n, err := io.Copy(io.MultiWriter(backupSparseWriter{f}, h), setupReader{&backupProgressReader{source: io.LimitReader(r, entry.Size+1), processed: processed, total: total, name: entry.Name, report: report}})
 	if err != nil {
 		return err
 	}
@@ -335,4 +345,23 @@ func restoreBackupFile(z *zip.File, target string, entry backupEntry) error {
 		return err
 	}
 	return f.Close()
+}
+
+// Progress is optional so archive tests and noninteractive callers never create UI.
+type backupProgress func(current, total int64, name string)
+type backupProgressReader struct {
+	source    io.Reader
+	processed *int64
+	total     int64
+	name      string
+	report    backupProgress
+}
+
+func (r *backupProgressReader) Read(p []byte) (int, error) {
+	n, err := r.source.Read(p)
+	*r.processed += int64(n)
+	if r.report != nil && n > 0 {
+		r.report(*r.processed, r.total, r.name)
+	}
+	return n, err
 }

--- a/app/backup_test.go
+++ b/app/backup_test.go
@@ -253,3 +253,26 @@ func TestVMRestoreRejectsIncompleteAndUnsupportedArchives(t *testing.T) {
 		t.Fatal("backed up missing kernel")
 	}
 }
+
+func TestBackupAndRestoreReportCompleteProgress(t *testing.T) {
+	dir, archive := backupFixture(t)
+	check := func(run func(backupProgress) error) {
+		var last, total int64
+		err := run(func(current, maximum int64, name string) {
+			if current < last || current > maximum || name == "" {
+				t.Errorf("invalid progress: %d/%d for %q", current, maximum, name)
+			}
+			last, total = current, maximum
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total == 0 || last != total {
+			t.Fatalf("incomplete progress: %d/%d", last, total)
+		}
+	}
+	check(func(report backupProgress) error { return writeVMBackupProgress(dir, archive, report) })
+	check(func(report backupProgress) error {
+		return restoreVMBackupProgress(archive, filepath.Join(filepath.Dir(dir), "progress-restore"), report)
+	})
+}

--- a/app/main.go
+++ b/app/main.go
@@ -143,6 +143,7 @@ func main() {
 	var forwards forwardList
 	flag.Var(&forwards, "forward", "forward a Windows loopback port into Omarchy, as tcp:2222:22 or 8080:80 (repeatable)")
 	sshPort := flag.Int("ssh", 0, "forward this Windows loopback port to Omarchy's sshd and start sshd for the session")
+	recoveryAction := flag.String("recovery", "", "open backup, restore, or reset controls for a stopped standard install")
 	backupPath := flag.String("backup", "", "back up a stopped standard VM to a new ZIP file, then exit")
 	restorePath := flag.String("restore", "", "restore a trusted backup into a new folder selected with -dir, then exit")
 	openSettings := flag.Bool("settings", false, "open the settings window, then exit")
@@ -164,12 +165,18 @@ func main() {
 	updateWaitPID := flag.Int("update-wait-pid", 0, "internal: process to wait for before replacing the launcher")
 	updateRestartArgs := flag.String("update-restart-args", "", "internal: encoded launcher restart arguments")
 	flag.Parse()
-	maintenance := *backupPath != "" || *restorePath != ""
+	maintenance := *backupPath != "" || *restorePath != "" || *recoveryAction != ""
+	if *recoveryAction != "" && (*recoveryAction != "backup" && *recoveryAction != "restore" && *recoveryAction != "reset" || *backupPath != "" || *restorePath != "") {
+		fatal("Choose one recovery action: backup, restore, or reset.")
+	}
 	if maintenance && (*backupPath != "" && *restorePath != "" || cfg.portable || cfg.fresh || *openSettings || *diagnostics || *enableWhp || *applyLauncherUpdateFlag || *applyLauncherRollbackFlag) {
-		fatal("Use either -backup or -restore on a stopped standard install, without other maintenance options.")
+		fatal("Use one recovery action on a stopped standard install, without other maintenance options.")
 	}
 	explicitFlags := map[string]bool{}
 	flag.Visit(func(f *flag.Flag) { explicitFlags[f.Name] = true })
+	if explicitFlags["recovery"] && *recoveryAction == "" {
+		fatal("Choose a recovery action: backup, restore, or reset.")
+	}
 	if explicitFlags["backup"] && strings.TrimSpace(*backupPath) == "" || explicitFlags["restore"] && strings.TrimSpace(*restorePath) == "" {
 		fatal("Provide a backup filename with -backup or -restore.")
 	}
@@ -250,14 +257,22 @@ func main() {
 		}
 	}
 
+	if *recoveryAction != "" {
+		err := runRecoveryUI(cfg.dir, *recoveryAction)
+		reportRecoveryResult(err)
+		if err != nil && !errors.Is(err, errSetupCancelled) {
+			os.Exit(1)
+		}
+		return
+	}
 	if maintenance {
 		var err error
 		if *backupPath != "" {
-			getUI().setStatus("Creating VM backup. This may take a while...")
-			err = writeVMBackup(cfg.dir, *backupPath)
+			beginRecoveryProgress("Creating VM backup. This may take a while...")
+			err = writeVMBackupProgress(cfg.dir, *backupPath, recoveryProgress("Backing up"))
 		} else {
-			getUI().setStatus("Verifying and restoring VM backup...")
-			err = restoreVMBackup(*restorePath, cfg.dir)
+			beginRecoveryProgress("Verifying and restoring VM backup...")
+			err = restoreVMBackupProgress(*restorePath, cfg.dir, recoveryProgress("Restoring"))
 		}
 		uiDone()
 		if err != nil {
@@ -332,6 +347,15 @@ func main() {
 	if cfg.portable {
 		cfg.diskFormat = "qcow2"
 		cfg.disk = filepath.Join(cfg.vmDir, "disk.qcow2")
+	}
+	if cfg.fresh && !cfg.portable {
+		if _, err := os.Lstat(cfg.disk); err == nil {
+			proceed, err := confirmResetBackup(cfg.dir)
+			if err != nil || !proceed {
+				reportRecoveryResult(err)
+				return
+			}
+		}
 	}
 	payloadsRolledBack, err := rollbackPendingPayloadUpdates(cfg.dir)
 	if err != nil {

--- a/app/qemu.go
+++ b/app/qemu.go
@@ -147,6 +147,10 @@ func prepareDisk(cfg *config, expandedMiB int64) error {
 		return err
 	}
 	expandedBytes := expandedMiB * 1024 * 1024
+	if cfg.fresh && !cfg.portable {
+		_, err := resetStandardDisk(cfg, expandedMiB)
+		return err
+	}
 	if cfg.fresh {
 		if err := os.Remove(cfg.disk); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("discarding the existing disk: %w", err)

--- a/app/qemu.go
+++ b/app/qemu.go
@@ -254,6 +254,9 @@ func prepareDisk(cfg *config, expandedMiB int64) error {
 	if err != nil {
 		return err
 	}
+	if !st.Mode().IsRegular() || st.Size() > expandedBytes {
+		return fmt.Errorf("factory image does not fit the requested disk capacity")
+	}
 	if err := sparseCopy(dst, src, st.Size(), ui); err != nil {
 		return err
 	}

--- a/app/recovery_dialog_windows.go
+++ b/app/recovery_dialog_windows.go
@@ -1,0 +1,128 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+type recoveryGUID struct {
+	A    uint32
+	B, C uint16
+	D    [8]byte
+}
+
+var recoveryOpenClass = recoveryGUID{0xdc1c5a9c, 0xe88a, 0x4dde, [8]byte{0xa5, 0xa1, 0x60, 0xf8, 0x2a, 0x20, 0xae, 0xf7}}
+var recoveryOpenIID = recoveryGUID{0xd57c7288, 0xd4ad, 0x4768, [8]byte{0xbe, 0x02, 0x9d, 0x96, 0x95, 0x32, 0xd9, 0x60}}
+var recoverySaveClass = recoveryGUID{0xc0b4e2f3, 0xba21, 0x4773, [8]byte{0x8d, 0xba, 0x33, 0x5e, 0xc9, 0x46, 0xeb, 0x8b}}
+var recoverySaveIID = recoveryGUID{0x84bccd23, 0x5fde, 0x4cdb, [8]byte{0xae, 0xa4, 0xaf, 0x64, 0xb8, 0x3d, 0x78, 0xab}}
+
+//go:uintptrescapes
+func recoveryCOMCall(object uintptr, index int, args ...uintptr) uintptr {
+	table := *(*uintptr)(unsafe.Pointer(object))
+	method := *(*uintptr)(unsafe.Pointer(table + uintptr(index)*unsafe.Sizeof(uintptr(0))))
+	result, _, _ := syscall.SyscallN(method, append([]uintptr{object}, args...)...)
+	return result
+}
+func recoveryCOMError(result uintptr) error {
+	if int32(result) < 0 {
+		return fmt.Errorf("Windows file picker failed (0x%08x)", uint32(result))
+	}
+	return nil
+}
+
+// Common Item Dialog uses the standard Windows file browser, including current
+// locations, search, keyboard navigation, and accessible system controls.
+func chooseRecoveryPath(owner uintptr, title, filename string, save, folder bool) (string, bool, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	init, _, _ := ole32.NewProc("CoInitializeEx").Call(0, 2)
+	if err := recoveryCOMError(init); err != nil {
+		return "", false, err
+	}
+	defer ole32.NewProc("CoUninitialize").Call()
+	class, iid := recoveryOpenClass, recoveryOpenIID
+	if save {
+		class, iid = recoverySaveClass, recoverySaveIID
+	}
+	var dialog uintptr
+	hr, _, _ := ole32.NewProc("CoCreateInstance").Call(uintptr(unsafe.Pointer(&class)), 0, 1, uintptr(unsafe.Pointer(&iid)), uintptr(unsafe.Pointer(&dialog)))
+	if err := recoveryCOMError(hr); err != nil {
+		return "", false, err
+	}
+	defer recoveryCOMCall(dialog, 2)
+	var options uint32
+	if err := recoveryCOMError(recoveryCOMCall(dialog, 10, uintptr(unsafe.Pointer(&options)))); err != nil {
+		return "", false, err
+	}
+	options |= 0x40 | 0x800 | 0x02000000 // filesystem, existing parent, no recent-items entry
+	if save {
+		options &^= 0x2
+	} // Existing backups are never overwritten.
+	if folder {
+		options |= 0x20
+	} else if !save {
+		options |= 0x1000
+	}
+	if err := recoveryCOMError(recoveryCOMCall(dialog, 9, uintptr(options))); err != nil {
+		return "", false, err
+	}
+	label, err := syscall.UTF16PtrFromString(title)
+	if err != nil {
+		return "", false, err
+	}
+	if err = recoveryCOMError(recoveryCOMCall(dialog, 17, uintptr(unsafe.Pointer(label)))); err != nil {
+		return "", false, err
+	}
+	if filename != "" {
+		name, err := syscall.UTF16PtrFromString(filename)
+		if err != nil {
+			return "", false, err
+		}
+		if err = recoveryCOMError(recoveryCOMCall(dialog, 15, uintptr(unsafe.Pointer(name)))); err != nil {
+			return "", false, err
+		}
+	}
+	if !folder {
+		label, _ := syscall.UTF16PtrFromString("Omarchy backups (*.zip)")
+		pattern, _ := syscall.UTF16PtrFromString("*.zip")
+		filter := struct{ label, pattern *uint16 }{label, pattern}
+		if err = recoveryCOMError(recoveryCOMCall(dialog, 4, 1, uintptr(unsafe.Pointer(&filter)))); err != nil {
+			return "", false, err
+		}
+		ext, _ := syscall.UTF16PtrFromString("zip")
+		if err = recoveryCOMError(recoveryCOMCall(dialog, 22, uintptr(unsafe.Pointer(ext)))); err != nil {
+			return "", false, err
+		}
+	}
+	hr = recoveryCOMCall(dialog, 3, owner)
+	if uint32(hr) == 0x800704c7 {
+		return "", false, nil
+	}
+	if err = recoveryCOMError(hr); err != nil {
+		return "", false, err
+	}
+	var item uintptr
+	if err = recoveryCOMError(recoveryCOMCall(dialog, 20, uintptr(unsafe.Pointer(&item)))); err != nil {
+		return "", false, err
+	}
+	defer recoveryCOMCall(item, 2)
+	var path *uint16
+	if err = recoveryCOMError(recoveryCOMCall(item, 5, 0x80058000, uintptr(unsafe.Pointer(&path)))); err != nil {
+		return "", false, err
+	}
+	defer procCoTaskMemFree.Call(uintptr(unsafe.Pointer(path)))
+	// Shell item paths are terminated UTF-16 strings owned by COM.
+	var chars []uint16
+	for offset := uintptr(0); offset < 32768; offset++ {
+		c := *(*uint16)(unsafe.Add(unsafe.Pointer(path), offset*2))
+		if c == 0 {
+			return syscall.UTF16ToString(chars), true, nil
+		}
+		chars = append(chars, c)
+	}
+	return "", false, fmt.Errorf("selected path is too long")
+}

--- a/app/recovery_windows.go
+++ b/app/recovery_windows.go
@@ -1,0 +1,176 @@
+//go:build windows
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func chooseBackupDestination() (string, bool, error) {
+	for {
+		name, ok, err := chooseRecoveryPath(0, "Save a new Omarchy backup", "Omarchy-"+time.Now().Format("2006-01-02-150405")+".zip", true, false)
+		if err != nil || !ok {
+			return "", ok, err
+		}
+		if _, err = os.Lstat(name); os.IsNotExist(err) {
+			return name, true, nil
+		} else if err != nil {
+			return "", false, err
+		}
+		infoBox("A file already exists there. Choose a new filename to keep both backups.")
+	}
+}
+
+func beginRecoveryProgress(status string) {
+	ui := getUI()
+	ui.cancelMessage.Store("Cancel this operation?\n\nThe original installation and completed backups will be kept. Temporary files will be removed.")
+	ui.setProgress(0, 0)
+	ui.setStatus("%s", status)
+}
+
+func runRecoveryUI(dir, action string) error {
+	configureSetupCancellation(false)
+	switch action {
+	case "backup":
+		name, ok, err := chooseBackupDestination()
+		if err != nil || !ok {
+			return err
+		}
+		beginRecoveryProgress("Creating your VM backup...")
+		defer uiDone()
+		if err = writeVMBackupProgress(dir, name, recoveryProgress("Backing up")); err != nil {
+			return err
+		}
+		uiDone()
+		infoBox("Backup saved to:\n\n" + name + "\n\nIt contains personal guest files and is not encrypted. Keep it private.")
+	case "restore":
+		source, ok, err := chooseRecoveryPath(0, "Choose a trusted Omarchy backup", "", false, false)
+		if err != nil || !ok {
+			return err
+		}
+		parent, ok, err := chooseRecoveryPath(0, "Choose where to create the restored copy", "", false, true)
+		if err != nil || !ok {
+			return err
+		}
+		destination := filepath.Join(parent, "OmarchyRestored-"+time.Now().Format("2006-01-02-150405"))
+		if msgBox("Restore this backup into a new folder?\n\n"+destination+"\n\nYour current installation and shortcuts will stay unchanged. Only restore backups you trust.", mbYesNo|mbIconQuestion|mbDefbutton2) != idYes {
+			return nil
+		}
+		beginRecoveryProgress("Verifying and restoring your VM...")
+		defer uiDone()
+		if err = restoreVMBackupProgress(source, destination, recoveryProgress("Restoring")); err != nil {
+			return err
+		}
+		uiDone()
+		if err := createRestoredLaunchers(destination); err != nil {
+			infoBox("Your data was restored to:\n\n" + destination + "\n\nThe startup shortcuts could not be created: " + err.Error() + "\n\nYou can start this copy with -dir pointing to its folder.")
+		} else {
+			infoBox("Restored to:\n\n" + destination + "\n\nOpen Start Omarchy in that folder to use this copy, or Settings to review it first. Your original installation and shortcuts are unchanged.")
+		}
+	case "reset":
+		return resetFromSettings(dir)
+	default:
+		return fmt.Errorf("unknown recovery action")
+	}
+	return nil
+}
+
+// Backup failure or cancellation must never fall through into reset.
+func confirmResetBackup(dir string) (bool, error) {
+	choice := msgBox("Start over with a clean Omarchy guest?\n\nThis resets the guest account, installed apps, and guest files. Windows shared folders and launcher settings are kept. The old disk will be retained for recovery.\n\nCreate a full backup first?\nYes: choose a backup. No: skip the full backup. Cancel: do nothing.", 3|mbIconQuestion|0x200)
+	if choice != idYes && choice != idNo {
+		return false, nil
+	}
+	if choice == idYes {
+		name, ok, err := chooseBackupDestination()
+		if err != nil || !ok {
+			return false, err
+		}
+		beginRecoveryProgress("Backing up before reset...")
+		if err = writeVMBackupProgress(dir, name, recoveryProgress("Backing up")); err != nil {
+			return false, err
+		}
+	}
+	if msgBox("Reset the active Omarchy guest now?\n\nThe old disk will remain in the VM folder until you remove it. The new guest needs first-run setup.", mbYesNo|mbIconQuestion|mbDefbutton2) != idYes {
+		return false, nil
+	}
+	return !setupCancelled(), checkSetupCancelled()
+}
+
+func resetFromSettings(dir string) error {
+	if !completeInstallExists(dir, "disk.raw") {
+		return fmt.Errorf("there is no complete standard installation to reset")
+	}
+	proceed, err := confirmResetBackup(dir)
+	if err != nil || !proceed {
+		return err
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "guest", "build-spec.json"))
+	if err != nil {
+		return err
+	}
+	var spec buildSpec
+	if err = json.Unmarshal(data, &spec); err != nil {
+		return err
+	}
+	storage, err := loadStorageSettings(dir)
+	if err != nil {
+		return err
+	}
+	cfg := &config{dir: dir, guestDir: filepath.Join(dir, "guest"), vmDir: filepath.Join(dir, "vm"), disk: filepath.Join(dir, "vm", "disk.raw"), diskFormat: "raw", diskGiB: storage.DiskGiB}
+	beginRecoveryProgress("Preparing a clean Omarchy guest...")
+	old, err := resetStandardDisk(cfg, spec.Runtime.Storage.ExpandedSizeMiB)
+	if err != nil {
+		return err
+	}
+	uiDone()
+	infoBox("Omarchy is ready for a fresh start on its next launch.\n\nThe previous disk is kept at:\n" + old + "\n\nKeep it until you have checked the new guest. It continues to use Windows disk space.")
+	return nil
+}
+
+func reportRecoveryResult(err error) {
+	uiDone()
+	if err != nil && !errors.Is(err, errSetupCancelled) {
+		errorBox("Try Omarchy could not finish this operation.\n\n" + err.Error())
+	}
+}
+
+// Place launchers beside the restored data, never over the original desktop or
+// Start-menu links. The explicit -dir argument keeps both installations separate.
+func createRestoredLaunchers(dir string) error {
+	target, err := stableLauncherPath(dir)
+	if err != nil {
+		return err
+	}
+	const script = `$ErrorActionPreference='Stop'; $shell=New-Object -ComObject WScript.Shell; ` +
+		`$items=@(@('Start Omarchy.lnk',$env:TRYOMARCHY_RESTORE_ARGS),@('Settings.lnk',($env:TRYOMARCHY_RESTORE_ARGS+' -settings'))); ` +
+		`foreach($item in $items){$path=Join-Path $env:TRYOMARCHY_RESTORE_DIR $item[0]; if(Test-Path -LiteralPath $path){throw 'Shortcut already exists'}; ` +
+		`$link=$shell.CreateShortcut($path); $link.TargetPath=$env:TRYOMARCHY_RESTORE_TARGET; $link.Arguments=$item[1]; $link.WorkingDirectory=$env:TRYOMARCHY_RESTORE_DIR; $link.IconLocation=$env:TRYOMARCHY_RESTORE_TARGET+',0'; $link.Save()}`
+	cmd := exec.Command(system32("WindowsPowerShell\\v1.0\\powershell.exe"), "-NoProfile", "-NonInteractive", "-Command", script)
+	cmd.Env = append(os.Environ(), "TRYOMARCHY_RESTORE_DIR="+dir, "TRYOMARCHY_RESTORE_TARGET="+target, "TRYOMARCHY_RESTORE_ARGS="+shortcutArguments(dir))
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: createNoWindow}
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("creating restored shortcuts: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return recordShortcutOffer(dir)
+}
+
+func recoveryProgress(action string) backupProgress {
+	last := ""
+	return func(current, total int64, name string) {
+		ui := getUI()
+		if name != last {
+			ui.setStatus("%s %s...", action, name)
+			last = name
+		}
+		ui.setProgress(current, total)
+	}
+}

--- a/app/recovery_windows_test.go
+++ b/app/recovery_windows_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,13 +20,49 @@ func TestRestoredShortcutsTargetOnlyRestoredFolder(t *testing.T) {
 	if err := createRestoredLaunchers(dir); err != nil {
 		t.Fatal(err)
 	}
-	const script = `$ErrorActionPreference='Stop'; $shell=New-Object -ComObject WScript.Shell; foreach($name in @('Start Omarchy.lnk','Settings.lnk')){ $link=$shell.CreateShortcut((Join-Path $env:TRYOMARCHY_TEST_DIR $name)); if($link.TargetPath -ne (Join-Path $env:TRYOMARCHY_TEST_DIR 'TryOmarchy.exe')){throw 'Wrong target'}; if($link.WorkingDirectory -ne $env:TRYOMARCHY_TEST_DIR){throw 'Wrong directory'}; $expected='-dir "'+$env:TRYOMARCHY_TEST_DIR+'"'; if($name -eq 'Settings.lnk'){$expected+=' -settings'}; if($link.Arguments -ne $expected){throw 'Wrong arguments'} }`
+	const script = `$ErrorActionPreference='Stop'; $shell=New-Object -ComObject WScript.Shell; $links=@(foreach($name in @('Start Omarchy.lnk','Settings.lnk')){ $link=$shell.CreateShortcut((Join-Path $env:TRYOMARCHY_TEST_DIR $name)); [pscustomobject]@{Name=$name;Target=$link.TargetPath;Arguments=$link.Arguments;Directory=$link.WorkingDirectory} }); ConvertTo-Json -Compress -InputObject $links`
+
 	cmd := exec.Command(system32("WindowsPowerShell\\v1.0\\powershell.exe"), "-NoProfile", "-NonInteractive", "-Command", script)
 	cmd.Env = append(os.Environ(), "TRYOMARCHY_TEST_DIR="+dir)
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: createNoWindow}
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("checking shortcuts: %v: %s", err, strings.TrimSpace(string(out)))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("reading shortcuts: %v: %s", err, strings.TrimSpace(string(out)))
 	}
+	var links []struct{ Name, Target, Arguments, Directory string }
+	if err := json.Unmarshal(out, &links); err != nil {
+		t.Fatalf("shortcut metadata: %v: %s", err, out)
+	}
+	if len(links) != 2 {
+		t.Fatalf("shortcuts: %s", out)
+	}
+	for _, link := range links {
+		// Windows Shell can expand 8.3 paths from the runner's temporary directory.
+		// Compare file identity instead of treating equivalent paths as different.
+		for actual, expected := range map[string]string{link.Target: filepath.Join(dir, stableLauncherName), link.Directory: dir} {
+			got, err := os.Stat(actual)
+			if err != nil {
+				t.Fatalf("shortcut %s: %v", actual, err)
+			}
+			want, err := os.Stat(expected)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !os.SameFile(got, want) {
+				t.Fatalf("shortcut %s points to %s, expected %s", link.Name, actual, expected)
+			}
+		}
+		wantArgs := `-dir "` + dir + `"`
+		if link.Name == "Settings.lnk" {
+			wantArgs += " -settings"
+		} else if link.Name != "Start Omarchy.lnk" {
+			t.Fatalf("unexpected shortcut %q", link.Name)
+		}
+		if link.Arguments != wantArgs {
+			t.Fatalf("shortcut arguments = %q, want %q", link.Arguments, wantArgs)
+		}
+	}
+
 	if !shortcutOfferRecorded(dir) {
 		t.Fatal("restored launch could offer to replace original shortcuts")
 	}

--- a/app/recovery_windows_test.go
+++ b/app/recovery_windows_test.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestRestoredShortcutsTargetOnlyRestoredFolder(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "Restored guest with spaces")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := createRestoredLaunchers(dir); err != nil {
+		t.Fatal(err)
+	}
+	const script = `$ErrorActionPreference='Stop'; $shell=New-Object -ComObject WScript.Shell; foreach($name in @('Start Omarchy.lnk','Settings.lnk')){ $link=$shell.CreateShortcut((Join-Path $env:TRYOMARCHY_TEST_DIR $name)); if($link.TargetPath -ne (Join-Path $env:TRYOMARCHY_TEST_DIR 'TryOmarchy.exe')){throw 'Wrong target'}; if($link.WorkingDirectory -ne $env:TRYOMARCHY_TEST_DIR){throw 'Wrong directory'}; $expected='-dir "'+$env:TRYOMARCHY_TEST_DIR+'"'; if($name -eq 'Settings.lnk'){$expected+=' -settings'}; if($link.Arguments -ne $expected){throw 'Wrong arguments'} }`
+	cmd := exec.Command(system32("WindowsPowerShell\\v1.0\\powershell.exe"), "-NoProfile", "-NonInteractive", "-Command", script)
+	cmd.Env = append(os.Environ(), "TRYOMARCHY_TEST_DIR="+dir)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: createNoWindow}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("checking shortcuts: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	if !shortcutOfferRecorded(dir) {
+		t.Fatal("restored launch could offer to replace original shortcuts")
+	}
+}

--- a/app/reset.go
+++ b/app/reset.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Prepare a replacement before moving the old disk. The retained folder also
+// survives a process interruption between the two publication renames.
+func resetStandardDisk(cfg *config, expandedMiB int64) (string, error) {
+	if cfg.portable {
+		return "", fmt.Errorf("reset with recovery is only supported for standard installs")
+	}
+	for _, name := range []string{payloadUpdateStateFilename, updateStateFilename} {
+		if _, err := os.Lstat(filepath.Join(cfg.dir, name)); !os.IsNotExist(err) {
+			return "", fmt.Errorf("finish the pending update before resetting")
+		}
+	}
+	if info, err := os.Lstat(cfg.disk); os.IsNotExist(err) {
+		copy := *cfg
+		copy.fresh = false
+		return "", prepareDisk(&copy, expandedMiB)
+	} else if err != nil {
+		return "", err
+	} else if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("reset requires a regular disk file")
+	}
+	lock, err := openBackupDisk(cfg.disk)
+	if err != nil {
+		return "", fmt.Errorf("close Omarchy before resetting: %w", err)
+	}
+	defer lock.Close()
+	stage, err := os.MkdirTemp(cfg.vmDir, ".reset-staging-*")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(stage)
+	next := *cfg
+	next.fresh = false
+	next.disk = filepath.Join(stage, "disk.raw")
+	next.vmDir = stage
+	if err = prepareDisk(&next, expandedMiB); err != nil {
+		return "", err
+	}
+	if err = checkSetupCancelled(); err != nil {
+		return "", err
+	}
+	retained, err := os.MkdirTemp(cfg.vmDir, "before-reset-*")
+	if err != nil {
+		return "", err
+	}
+	old := filepath.Join(retained, "disk.raw")
+	if err = lock.Close(); err != nil {
+		os.Remove(retained)
+		return "", err
+	}
+	if err = publishResetDisk(cfg.disk, next.disk, old, os.Rename); err != nil {
+		// Remove only an empty retention folder. A failed rollback leaves the
+		// previous disk there and reports its location to the user.
+		_ = os.Remove(retained)
+		return "", err
+	}
+	return old, nil
+}
+
+func publishResetDisk(current, staged, retained string, rename func(string, string) error) error {
+	if err := rename(current, retained); err != nil {
+		return err
+	}
+	if err := rename(staged, current); err != nil {
+		if rollbackErr := rename(retained, current); rollbackErr != nil {
+			return fmt.Errorf("reset failed: %v; previous disk remains at %s: %w", err, retained, rollbackErr)
+		}
+		return err
+	}
+	return nil
+}

--- a/app/reset_test.go
+++ b/app/reset_test.go
@@ -53,7 +53,7 @@ func TestResetRetainsPreviousDiskAndPublishesFactory(t *testing.T) {
 }
 
 func TestResetFailuresPreserveOriginal(t *testing.T) {
-	for _, mode := range []string{"missing-factory", "low-space", "cancelled", "locked", "pending-update", "invalid-size"} {
+	for _, mode := range []string{"missing-factory", "low-space", "cancelled", "locked", "pending-update", "invalid-size", "oversized-factory"} {
 		t.Run(mode, func(t *testing.T) {
 			cfg := resetFixture(t)
 			size := int64(1)
@@ -78,6 +78,10 @@ func TestResetFailuresPreserveOriginal(t *testing.T) {
 				}
 			case "invalid-size":
 				size = -1
+			case "oversized-factory":
+				if err := os.WriteFile(filepath.Join(cfg.guestDir, "rootfs.ext4"), make([]byte, 2<<20), 0600); err != nil {
+					t.Fatal(err)
+				}
 			}
 			_, err := resetStandardDisk(cfg, size)
 			if err == nil {

--- a/app/reset_test.go
+++ b/app/reset_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func resetFixture(t *testing.T) *config {
+	t.Helper()
+	configureSetupCancellation(false)
+	dir := t.TempDir()
+	cfg := &config{dir: dir, guestDir: filepath.Join(dir, "guest"), vmDir: filepath.Join(dir, "vm"), disk: filepath.Join(dir, "vm", "disk.raw"), diskFormat: "raw"}
+	for _, folder := range []string{cfg.guestDir, cfg.vmDir} {
+		if err := os.MkdirAll(folder, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(cfg.disk, []byte("existing personal files"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg.guestDir, "rootfs.ext4"), []byte("factory image"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}
+
+func TestResetRetainsPreviousDiskAndPublishesFactory(t *testing.T) {
+	cfg := resetFixture(t)
+	old, err := resetStandardDisk(cfg, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous, err := os.ReadFile(old)
+	if err != nil || string(previous) != "existing personal files" {
+		t.Fatalf("retained disk: %q, %v", previous, err)
+	}
+	current, err := os.ReadFile(cfg.disk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(current) != 1<<20 || !bytes.HasPrefix(current, []byte("factory image")) {
+		t.Fatal("replacement disk is incomplete")
+	}
+	leftovers, _ := filepath.Glob(filepath.Join(cfg.vmDir, ".reset-staging-*"))
+	if len(leftovers) != 0 {
+		t.Fatal("left staging files")
+	}
+}
+
+func TestResetFailuresPreserveOriginal(t *testing.T) {
+	for _, mode := range []string{"missing-factory", "low-space", "cancelled", "locked", "pending-update", "invalid-size"} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := resetFixture(t)
+			size := int64(1)
+			saved := diskFreeBytes
+			t.Cleanup(func() { diskFreeBytes = saved; configureSetupCancellation(false) })
+			switch mode {
+			case "missing-factory":
+				os.Remove(filepath.Join(cfg.guestDir, "rootfs.ext4"))
+			case "low-space":
+				diskFreeBytes = func(string) (int64, error) { return 0, nil }
+			case "cancelled":
+				requestSetupCancel()
+			case "locked":
+				lock, err := openBackupDisk(cfg.disk)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { lock.Close() })
+			case "pending-update":
+				if err := os.WriteFile(filepath.Join(cfg.dir, payloadUpdateStateFilename), []byte("pending"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "invalid-size":
+				size = -1
+			}
+			_, err := resetStandardDisk(cfg, size)
+			if err == nil {
+				t.Fatal("reset succeeded")
+			}
+			if mode == "low-space" && !errors.Is(err, errInsufficientDiskSpace) {
+				t.Fatalf("unexpected space failure: %v", err)
+			}
+			// Release the test's exclusive handle before reading on Windows.
+			if mode == "locked" {
+				return
+			}
+			current, readErr := os.ReadFile(cfg.disk)
+			if readErr != nil || string(current) != "existing personal files" {
+				t.Fatalf("original changed: %q, %v", current, readErr)
+			}
+		})
+	}
+}
+
+func TestFreshStandardInstallUsesSafeReset(t *testing.T) {
+	cfg := resetFixture(t)
+	cfg.fresh = true
+	if err := prepareDisk(cfg, 1); err != nil {
+		t.Fatal(err)
+	}
+	retained, _ := filepath.Glob(filepath.Join(cfg.vmDir, "before-reset-*", "disk.raw"))
+	if len(retained) != 1 {
+		t.Fatalf("retained disks: %v", retained)
+	}
+	content, _ := os.ReadFile(retained[0])
+	if string(content) != "existing personal files" {
+		t.Fatal("fresh lost the old disk")
+	}
+}
+
+func TestResetPublicationFailurePreservesRecovery(t *testing.T) {
+	for _, rollbackFails := range []bool{false, true} {
+		t.Run(fmt.Sprint(rollbackFails), func(t *testing.T) {
+			dir := t.TempDir()
+			current := filepath.Join(dir, "disk.raw")
+			staged := filepath.Join(dir, "new.raw")
+			retained := filepath.Join(dir, "old.raw")
+			if err := os.WriteFile(current, []byte("personal files"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(staged, []byte("factory"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			err := publishResetDisk(current, staged, retained, func(from, to string) error {
+				if from == staged || rollbackFails && from == retained {
+					return errors.New("simulated publication failure")
+				}
+				return os.Rename(from, to)
+			})
+			if err == nil {
+				t.Fatal("expected publication failure")
+			}
+			preserved := current
+			if rollbackFails {
+				preserved = retained
+				if !strings.Contains(err.Error(), retained) {
+					t.Fatal("missing recovery location")
+				}
+			}
+			data, readErr := os.ReadFile(preserved)
+			if readErr != nil || string(data) != "personal files" {
+				t.Fatalf("lost previous disk: %q %v", data, readErr)
+			}
+		})
+	}
+}

--- a/app/settings_dialog_windows.go
+++ b/app/settings_dialog_windows.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -29,34 +30,38 @@ var (
 )
 
 const (
-	wsCaption         = 0x00C00000
-	wsSysmenu         = 0x00080000
-	wsBorder          = 0x00800000
-	wsTabstop         = 0x00010000
-	wsVscroll         = 0x00200000
-	esAutohscroll     = 0x0080
-	esMultiline       = 0x0004
-	esAutovscroll     = 0x0040
-	bsAutocheckbox    = 0x0003
-	bsDefpushbutton   = 0x0001
-	bmGetcheck        = 0x00F0
-	bmSetcheck        = 0x00F1
-	bstChecked        = 1
-	idcArrow          = 32512
-	colorBtnface      = 15
-	defaultGuiFont    = 17
-	wmGettextlength   = 0x000E
-	wmGettext         = 0x000D
-	settingsSaveID    = 2001
-	settingsCancelID  = 2002
-	settingsBrowseID  = 2003
-	settingsFullID    = 2010
-	settingsMemID     = 2011
-	settingsShareID   = 2012
-	settingsFwdID     = 2013
-	settingsKeyID     = 2014
-	settingsShareOnID = 2015
-	settingsDiskID    = 2016
+	wsCaption            = 0x00C00000
+	wsSysmenu            = 0x00080000
+	wsBorder             = 0x00800000
+	wsTabstop            = 0x00010000
+	wsVscroll            = 0x00200000
+	esAutohscroll        = 0x0080
+	esMultiline          = 0x0004
+	esAutovscroll        = 0x0040
+	bsAutocheckbox       = 0x0003
+	bsDefpushbutton      = 0x0001
+	bmGetcheck           = 0x00F0
+	bmSetcheck           = 0x00F1
+	bstChecked           = 1
+	idcArrow             = 32512
+	colorBtnface         = 15
+	defaultGuiFont       = 17
+	wmGettextlength      = 0x000E
+	wmGettext            = 0x000D
+	settingsSaveID       = 2001
+	settingsCancelID     = 2002
+	settingsBrowseID     = 2003
+	settingsFullID       = 2010
+	settingsMemID        = 2011
+	settingsShareID      = 2012
+	settingsFwdID        = 2013
+	settingsKeyID        = 2014
+	settingsShareOnID    = 2015
+	settingsDiskID       = 2016
+	settingsBackupID     = 2020
+	settingsRestoreID    = 2021
+	settingsResetID      = 2022
+	settingsRecoveryDone = 0x8010
 )
 
 // runSettingsDialog shows the window and returns once it closes. saved is
@@ -102,6 +107,23 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 		}
 	}
 
+	launchRecovery := func(action string) {
+		self, err := os.Executable()
+		if err != nil {
+			errorBox(err.Error())
+			return
+		}
+		cmd := exec.Command(self, "-dir", dataDir, "-recovery", action)
+		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: createNoWindow}
+		if err = cmd.Start(); err != nil {
+			errorBox("Could not open recovery controls:\n\n" + err.Error())
+			return
+		}
+		procAllowSetForeground.Call(uintptr(cmd.Process.Pid))
+		procEnableWindow.Call(hwnd, 0)
+		go func() { _ = cmd.Wait(); procPostMessageW.Call(hwnd, settingsRecoveryDone, 0, 0) }()
+	}
+
 	wndProc := syscall.NewCallback(func(h, msg, wParam, lParam uintptr) uintptr {
 		switch msg {
 		case wmCommand:
@@ -139,7 +161,17 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 				procDestroyWindow.Call(h)
 			case settingsBrowseID:
 				browseFolder()
+			case settingsBackupID:
+				launchRecovery("backup")
+			case settingsRestoreID:
+				launchRecovery("restore")
+			case settingsResetID:
+				launchRecovery("reset")
 			}
+			return 0
+		case settingsRecoveryDone:
+			procEnableWindow.Call(h, 1)
+			procSetForegroundWindow.Call(h)
 			return 0
 		case wmClose:
 			procDestroyWindow.Call(h)
@@ -170,7 +202,7 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 		return false
 	}
 
-	const clientW, clientH = 480, 488
+	const clientW, clientH = 480, 558
 	rect := [4]int32{0, 0, clientW, clientH}
 	style := uintptr(wsCaption | wsSysmenu)
 	procAdjustWindowRectEx.Call(uintptr(unsafe.Pointer(&rect[0])), style, 0, 0)
@@ -204,6 +236,7 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 	y += 34
 	mk("STATIC", "Guest memory (MiB)", left, y+3, labelW, 20, ssNoprefix, 0)
 	hMem = mk("EDIT", strconv.Itoa(current.MemoryMiB), fieldX, y, 100, 24, wsBorder|wsTabstop|esAutohscroll, settingsMemID)
+	mk("STATIC", "0 = automatic", fieldX+112, y+3, fieldW-112, 20, ssNoprefix, 0)
 	y += 34
 	mk("STATIC", "Disk capacity (GiB)", left, y+3, labelW, 20, ssNoprefix, 0)
 	hDisk = mk("EDIT", strconv.Itoa(storage.DiskGiB), fieldX, y, 100, 24, wsBorder|wsTabstop|esAutohscroll, settingsDiskID)
@@ -247,6 +280,25 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 	y += 36
 	mk("STATIC", "Changes apply the next time Omarchy starts.",
 		left, y, clientW-2*left, 36, ssNoprefix, 0)
+	y += 34
+	mk("STATIC", "Backup and recovery", left, y, clientW-2*left, 20, ssNoprefix, 0)
+	y += 24
+	for _, control := range []struct {
+		label string
+		id    uintptr
+		x     int32
+	}{{"Back up...", settingsBackupID, left}, {"Restore...", settingsRestoreID, left + 150}, {"Reset guest...", settingsResetID, left + 300}} {
+		button := mk("BUTTON", control.label, control.x, y, 140, 26, wsTabstop, control.id)
+		if portable {
+			procEnableWindow.Call(button, 0)
+		}
+	}
+	y += 30
+	help := "Close Omarchy first. Backups use saved settings. Restore creates a separate copy."
+	if portable {
+		help = "Backup and recovery controls are available for standard installs."
+	}
+	mk("STATIC", help, left, y, clientW-2*left, 34, ssNoprefix, 0)
 	mk("BUTTON", "Save", clientW-16-180, clientH-40, 84, 26, bsDefpushbutton|wsTabstop, settingsSaveID)
 	mk("BUTTON", "Cancel", clientW-16-84, clientH-40, 84, 26, wsTabstop, settingsCancelID)
 	// Settings is often opened from the tray while the maximized QEMU window

--- a/app/ui.go
+++ b/app/ui.go
@@ -116,15 +116,16 @@ type setupPromptResult struct {
 }
 
 type progressUI struct {
-	status    atomic.Value // string
-	account   atomic.Value // string
-	cur       atomic.Int64
-	total     atomic.Int64
-	done      atomic.Bool
-	canceling atomic.Bool
-	available atomic.Bool
-	ready     chan struct{}
-	prompts   chan setupPromptRequest
+	status        atomic.Value // string
+	cancelMessage atomic.Value // string
+	account       atomic.Value // string
+	cur           atomic.Int64
+	total         atomic.Int64
+	done          atomic.Bool
+	canceling     atomic.Bool
+	available     atomic.Bool
+	ready         chan struct{}
+	prompts       chan setupPromptRequest
 }
 
 // THE app has ONE splash (launch-UX requirement: it appears at launch and
@@ -200,7 +201,11 @@ func (ui *progressUI) confirmCancel(hCancel uintptr) bool {
 	if ui.canceling.Load() {
 		return true
 	}
-	if msgBox("Cancel Try Omarchy setup?\n\nUnfinished setup files will be removed. An existing working installation will be kept.", mbYesNo|mbIconQuestion|mbDefbutton2) != idYes {
+	message := "Cancel Try Omarchy setup?\n\nUnfinished setup files will be removed. An existing working installation will be kept."
+	if custom, ok := ui.cancelMessage.Load().(string); ok {
+		message = custom
+	}
+	if msgBox(message, mbYesNo|mbIconQuestion|mbDefbutton2) != idYes {
 		return false
 	}
 	if !ui.canceling.CompareAndSwap(false, true) {
@@ -507,7 +512,7 @@ func (ui *progressUI) run() {
 	hLabelTerminal = mk("Terminal", 150, 310, 90, 20, 0, 0)
 	hKeyW = mk("SUPER+W", 280, 310, 86, 20, 0, 0)
 	hLabelClose = mk("Close window", 368, 310, 100, 20, 0, 0)
-	hCancel = mk("CANCEL SETUP", 380, 342, 100, 20, ssNotify, cancelControlID)
+	hCancel = mk("CANCEL", 380, 342, 100, 20, ssNotify, cancelControlID)
 	hPromptTitle = mk("", 40, 168, windowW-80, 24, 0, 0)
 	hPromptBody = mk("", 40, 200, windowW-80, 22, 0, 0)
 	hPromptOption1 = mk("", 40, 238, windowW-80, 24, ssNotify, promptOption1ID)

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,11 +1,34 @@
 # VM backup and restore
 
-The development build supports full backups of stopped standard installs.
-Portable installs are not supported yet. These commands are separate from
+The development build supports backup, restore, and reset controls in Settings
+for stopped standard installs. Portable installs are not supported yet. These
+operations are separate from
 [configuration export](MIGRATION.md), which transfers your setup to a physical
 Omarchy installation.
 
-## Create a backup
+## Use Settings
+
+Open Settings and use **Back up**, **Restore**, or **Reset guest** under Backup
+and recovery. Close the Omarchy VM first. Recovery uses the settings already
+saved on disk; edits in the Settings window remain available after the operation.
+
+- **Back up** opens the Windows save dialog. Choose a new ZIP filename outside
+  the installation folder.
+- **Restore** asks for a backup and a parent folder, then creates a separate
+  restored installation. It adds **Start Omarchy** and **Settings** shortcuts
+  inside that new folder. Existing Windows shortcuts are unchanged.
+- **Reset guest** offers a full backup first, then asks for confirmation. A
+  failed or cancelled backup stops the reset. The factory disk is prepared
+  before the old disk is moved into a `vm/before-reset-*` folder. The next normal
+  launch starts first-run setup. Windows shared folders and launcher settings
+  are kept.
+
+Backup and restore show file progress and support cancellation. Reset retains
+only the previous writable disk, not a complete backup of its boot files and
+runtime. Keep a full backup before updating or removing the old installation.
+The retained disk continues using host space until you remove it yourself.
+
+## Create a backup from PowerShell
 
 Shut down Omarchy and close the launcher first. From PowerShell:
 
@@ -63,5 +86,5 @@ to read even when mostly empty.
 Automated tests cover copying, checksums, cancellation, disk locking, low space,
 and preservation of existing folders. A restored guest still needs a Windows
 boot test before release. Keep the original installation until you have checked
-the restored copy. A Settings workflow and backup-before-reset controls remain
-planned in #36.
+the restored copy. The Settings dialogs and a restored guest boot still need hands-on Windows
+validation before release (#36).

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -24,6 +24,6 @@ Try Omarchy runs the full x86_64 Arch Linux environment used by Omarchy. It is n
 - Text clipboard sharing works in both directions. File clipboard and drag and
   drop are not implemented yet; use the shared folder for files.
 - The launcher boots its pinned kernel and initramfs from the release image. Ordinary package installation is supported, but replacing the guest kernel independently can leave it out of sync with those boot files.
-- Configuration export and restore are available through `try-omarchy-export`; see [the migration guide](MIGRATION.md). Development builds also support [stopped-VM backup and restore](BACKUP.md) through command-line options. Snapshots and backup controls in Settings are not available yet.
+- Configuration export and restore are available through `try-omarchy-export`; see [the migration guide](MIGRATION.md). Development builds also support [stopped-VM backup and restore](BACKUP.md) from Settings or command-line options. Reset can retain the old disk and offer a full backup first. Snapshots are not available yet.
 
 Compatibility varies with Windows, CPU, GPU, and driver combinations. When reporting a problem, include those details and whether Try Omarchy selected GPU or CPU rendering.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -62,6 +62,12 @@ Use the copied guest for interruption and low-space tests.
   on its next update check. Test direct stable install and stable-to-stable too.
 - [ ] Grow the disk, verify capacity inside Omarchy with `df -h /`, and check the
   files. Lowering the preference and rolling back the launcher never shrink it.
+- [ ] From Settings, back up a stopped VM, cancel an operation, and restore a
+  separate copy. Verify its Start Omarchy and Settings shortcuts point to that
+  copy, then boot it and compare the guest files.
+- [ ] Reset from Settings after taking a backup. Confirm first-run setup on the
+  next launch and that the previous disk is retained under `vm/before-reset-*`.
+  Check keyboard navigation, file pickers, progress, and scaling of the controls.
 - [ ] Low host free space produces a useful error and leaves the existing guest
   usable after space is freed.
 - [ ] Configuration export restores the selected theme, personal configuration,


### PR DESCRIPTION
Add backup, restore, and reset controls to Settings, with Windows file pickers, progress, and cancellation. Restored copies get their own launch and Settings shortcuts.

Standard resets prepare the new disk before moving the old one, retain the previous disk, and offer a full backup first. Failed or cancelled backups stop the reset.

Tested: Go race tests, vet, Windows build, reset failure recovery, and backup progress. Windows CI covers disk operations and restored shortcuts. Visual and guest boot checks remain pending in #36.
