### PR TITLE
Improve preference recovery and folder selection

### DIFF
--- a/app/folder_dialog_windows.go
+++ b/app/folder_dialog_windows.go
@@ -2,42 +2,12 @@
 
 package main
 
-import (
-	"syscall"
-	"unsafe"
-)
-
-var (
-	procSHBrowseForFolderW   = shell32.NewProc("SHBrowseForFolderW")
-	procSHGetPathFromIDListW = shell32.NewProc("SHGetPathFromIDListW")
-	procCoTaskMemFree        = ole32.NewProc("CoTaskMemFree")
-)
-
-const bifReturnOnlyFS = 0x0001
-
-type browseInfo struct {
-	owner       uintptr
-	root        uintptr
-	displayName *uint16
-	title       *uint16
-	flags       uint32
-	callback    uintptr
-	param       uintptr
-	image       int32
-}
+var procCoTaskMemFree = ole32.NewProc("CoTaskMemFree")
 
 func browseForFolder(owner uintptr, prompt string) (string, bool) {
-	var display [260]uint16
-	title, _ := syscall.UTF16PtrFromString(prompt)
-	bi := browseInfo{owner: owner, displayName: &display[0], title: title, flags: bifReturnOnlyFS}
-	pidl, _, _ := procSHBrowseForFolderW.Call(uintptr(unsafe.Pointer(&bi)))
-	if pidl == 0 {
-		return "", false
+	selected, ok, err := chooseRecoveryPath(owner, prompt, "", false, true)
+	if err != nil {
+		errorBox("Windows could not open the folder picker.\n\n" + err.Error())
 	}
-	defer procCoTaskMemFree.Call(pidl)
-	var pathBuf [32768]uint16
-	if ok, _, _ := procSHGetPathFromIDListW.Call(pidl, uintptr(unsafe.Pointer(&pathBuf[0]))); ok != 0 {
-		return syscall.UTF16ToString(pathBuf[:]), true
-	}
-	return "", false
+	return selected, ok
 }

--- a/app/main.go
+++ b/app/main.go
@@ -275,6 +275,9 @@ func main() {
 			err = restoreVMBackupProgress(*restorePath, cfg.dir, recoveryProgress("Restoring"))
 		}
 		uiDone()
+		if errors.Is(err, errSetupCancelled) {
+			return
+		}
 		if err != nil {
 			errorBox("Try Omarchy could not finish the backup or restore.\n\n" + err.Error())
 			os.Exit(1)
@@ -309,8 +312,12 @@ func main() {
 	// settings.json holds the rows the settings window edits; explicit flags
 	// win for this launch only.
 	settingsFile := settingsPath(cfg.dir)
-	userSettings, err := loadSettings(settingsFile)
+	userSettings, err := loadSettingsWithRepair(settingsFile)
 	if err != nil {
+		if errors.Is(err, errSetupCancelled) {
+			uiDone()
+			return
+		}
 		fatal("Try Omarchy cannot read its settings: %v\n\nFix or delete the file and open Try Omarchy again.", err)
 	}
 	if err := applySettings(cfg, userSettings, explicitFlags, &forwards, sshKeyPath); err != nil {
@@ -320,8 +327,12 @@ func main() {
 		fatal("-memory must be between %d and %d MiB.", minimumGuestMemoryMiB, maximumGuestMemoryMiB)
 	}
 	if !explicitFlags["disk-size"] {
-		storage, err := loadStorageSettings(cfg.dir)
+		storage, err := loadStorageWithRepair(cfg.dir)
 		if err != nil {
+			if errors.Is(err, errSetupCancelled) {
+				uiDone()
+				return
+			}
 			fatal("Cannot read storage preferences: %v", err)
 		}
 		cfg.diskGiB = storage.DiskGiB

--- a/app/preferences_repair.go
+++ b/app/preferences_repair.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Preserve the original preferences before replacing them with valid defaults.
+// Only preferences are touched; guest disks, payloads, and shortcuts are separate.
+func repairPreferences(path string) (string, error) {
+	var write func() error
+	switch filepath.Base(path) {
+	case settingsFileName:
+		write = func() error { return saveSettings(path, settings{ShareDisabled: true, SharedFolderPrompted: true}) }
+	case storageSettingsFilename:
+		write = func() error { return saveStorageSettings(filepath.Dir(path), 0) }
+	default:
+		return "", fmt.Errorf("not a supported preferences file")
+	}
+	return preserveAndRepairPreferences(path, write)
+}
+
+func preserveAndRepairPreferences(path string, write func() error) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() || info.Size() > 4<<20 {
+		return "", fmt.Errorf("preferences must be a regular file no larger than 4 MiB; the original was left unchanged")
+	}
+	source, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer source.Close()
+	dir, err := os.MkdirTemp(filepath.Dir(path), "preferences-before-repair-*")
+	if err != nil {
+		return "", err
+	}
+	saved := filepath.Join(dir, filepath.Base(path))
+	out, err := os.OpenFile(saved, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		os.RemoveAll(dir)
+		return "", err
+	}
+	n, copyErr := io.Copy(out, io.LimitReader(source, (4<<20)+1))
+	syncErr := out.Sync()
+	closeErr := out.Close()
+	if n != info.Size() {
+		copyErr = fmt.Errorf("preferences changed while being copied")
+	}
+	if copyErr != nil || syncErr != nil || closeErr != nil {
+		os.RemoveAll(dir)
+		return "", fmt.Errorf("could not preserve preferences; the original was left unchanged: %v", errors.Join(copyErr, syncErr, closeErr))
+	}
+	if err := source.Close(); err != nil {
+		return saved, err
+	}
+	current, err := os.Stat(path)
+	if err != nil || !os.SameFile(info, current) || !current.ModTime().Equal(info.ModTime()) || current.Size() != info.Size() {
+		return saved, fmt.Errorf("preferences changed during repair; try again")
+	}
+	if err = write(); err != nil {
+		return saved, fmt.Errorf("could not save defaults; original preferences are backed up at %s: %w", saved, err)
+	}
+	return saved, nil
+}

--- a/app/preferences_repair_test.go
+++ b/app/preferences_repair_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRepairPreferencesPreservesOriginalAndGuest(t *testing.T) {
+	for _, name := range []string{settingsFileName, storageSettingsFilename} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			file := filepath.Join(dir, name)
+			original := []byte(`{"broken preferences`)
+			if err := os.WriteFile(file, original, 0600); err != nil {
+				t.Fatal(err)
+			}
+			guest := filepath.Join(dir, "disk.raw")
+			if err := os.WriteFile(guest, []byte("guest files"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			saved, err := repairPreferences(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.ReadFile(saved)
+			if err != nil || !bytes.Equal(before, original) {
+				t.Fatalf("original preferences lost: %q %v", before, err)
+			}
+			if name == settingsFileName {
+				value, err := loadSettings(file)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if value.activeShare() != "" || len(value.Forwards) != 0 || !value.ShareDisabled || !value.SharedFolderPrompted {
+					t.Fatalf("unexpected restored defaults: %+v", value)
+				}
+			} else {
+				value, err := loadStorageSettings(dir)
+				if err != nil || value.DiskGiB != 0 {
+					t.Fatalf("storage defaults: %+v %v", value, err)
+				}
+			}
+			data, err := os.ReadFile(guest)
+			if err != nil || string(data) != "guest files" {
+				t.Fatal("repair touched guest files")
+			}
+		})
+	}
+}
+
+func TestRepairPreferencesWriteFailureKeepsOriginal(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, settingsFileName)
+	original := []byte("broken")
+	if err := os.WriteFile(file, original, 0600); err != nil {
+		t.Fatal(err)
+	}
+	injected := errors.New("simulated write failure")
+	saved, err := preserveAndRepairPreferences(file, func() error { return injected })
+	if !errors.Is(err, injected) {
+		t.Fatalf("write error: %v", err)
+	}
+	for _, path := range []string{file, saved} {
+		data, err := os.ReadFile(path)
+		if err != nil || !bytes.Equal(data, original) {
+			t.Fatalf("lost preferences at %s", path)
+		}
+	}
+}
+
+func TestRepairPreferencesRejectsUnexpectedFiles(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "disk.raw")
+	if err := os.WriteFile(file, []byte("guest"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repairPreferences(file); err == nil {
+		t.Fatal("accepted a disk as preferences")
+	}
+	folder := filepath.Join(dir, settingsFileName)
+	if err := os.Mkdir(folder, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repairPreferences(folder); err == nil {
+		t.Fatal("accepted a directory as preferences")
+	}
+	data, _ := os.ReadFile(file)
+	if string(data) != "guest" {
+		t.Fatal("changed guest data")
+	}
+}

--- a/app/preferences_repair_windows.go
+++ b/app/preferences_repair_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package main
+
+import "path/filepath"
+
+func offerPreferencesRepair(path string, cause error) error {
+	if msgBox("Try Omarchy cannot read "+filepath.Base(path)+".\n\n"+cause.Error()+"\n\nRestore these preferences to their defaults? The original file will be backed up first. Guest files and the VM disk will not be changed.", mbYesNo|mbIconQuestion|mbDefbutton2) != idYes {
+		return errSetupCancelled
+	}
+	saved, err := repairPreferences(path)
+	if err != nil {
+		return err
+	}
+	infoBox("Default preferences restored.\n\nThe previous file is kept at:\n" + saved + "\n\nReview your settings before enabling a shared folder or port forwarding again.")
+	return nil
+}
+
+func loadSettingsWithRepair(path string) (settings, error) {
+	value, err := loadSettings(path)
+	if err == nil {
+		return value, nil
+	}
+	if err = offerPreferencesRepair(path, err); err != nil {
+		return settings{}, err
+	}
+	return loadSettings(path)
+}
+func loadStorageWithRepair(dir string) (storageSettings, error) {
+	value, err := loadStorageSettings(dir)
+	if err == nil {
+		return value, nil
+	}
+	if err = offerPreferencesRepair(filepath.Join(dir, storageSettingsFilename), err); err != nil {
+		return storageSettings{}, err
+	}
+	return loadStorageSettings(dir)
+}

--- a/app/recovery_windows_test.go
+++ b/app/recovery_windows_test.go
@@ -39,7 +39,8 @@ func TestRestoredShortcutsTargetOnlyRestoredFolder(t *testing.T) {
 	for _, link := range links {
 		// Windows Shell can expand 8.3 paths from the runner's temporary directory.
 		// Compare file identity instead of treating equivalent paths as different.
-		for actual, expected := range map[string]string{link.Target: filepath.Join(dir, stableLauncherName), link.Directory: dir} {
+		for _, pair := range [][2]string{{link.Target, filepath.Join(dir, stableLauncherName)}, {link.Directory, dir}} {
+			actual, expected := pair[0], pair[1]
 			got, err := os.Stat(actual)
 			if err != nil {
 				t.Fatalf("shortcut %s: %v", actual, err)

--- a/app/settings_dialog_windows.go
+++ b/app/settings_dialog_windows.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -68,14 +69,20 @@ const (
 // true when the file was written.
 func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 	runtime.LockOSThread()
-	current, err := loadSettings(path)
+	current, err := loadSettingsWithRepair(path)
 	if err != nil {
+		if errors.Is(err, errSetupCancelled) {
+			return false
+		}
 		errorBox("Try Omarchy cannot read its settings:\n\n" + err.Error() + "\n\nFix or delete the file, then open the settings again.")
 		return false
 	}
 
-	storage, err := loadStorageSettings(dataDir)
+	storage, err := loadStorageWithRepair(dataDir)
 	if err != nil {
+		if errors.Is(err, errSetupCancelled) {
+			return false
+		}
 		errorBox("Try Omarchy cannot read its storage preferences:\n\n" + err.Error())
 		return false
 	}

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -28,6 +28,15 @@ only the previous writable disk, not a complete backup of its boot files and
 runtime. Keep a full backup before updating or removing the old installation.
 The retained disk continues using host space until you remove it yourself.
 
+## Repair unreadable preferences
+
+If a preferences file cannot be read, the launcher or Settings offers to restore
+that file's defaults. Choose No to leave it unchanged. Choose Yes to keep a copy
+under `preferences-before-repair-*` in the data folder before saving defaults.
+Guest files, disk capacity already allocated, and Windows shortcuts are untouched.
+Repairing launcher settings leaves shared folders and port forwarding disabled
+until you configure them again.
+
 ## Create a backup from PowerShell
 
 Shut down Omarchy and close the launcher first. From PowerShell:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -29,7 +29,11 @@ personal details. Do not upload the guest disk or a full backup.
 
 ## Everyday use
 
-- [ ] Fresh install at the default location and another local drive.
+- [ ] Fresh install at the default location and another local drive. Use the
+  Windows folder picker for install location and sharing, including a long path.
+- [ ] On a copied install, confirm that malformed preferences offer repair,
+  declining leaves them unchanged, and accepting preserves the original file
+  before restoring defaults without changing guest files.
 - [ ] Cancel a download, relaunch, and finish setup without a broken install.
 - [ ] Instant account and personalized account both reach the desktop.
 - [ ] GPU rendering, then CPU fallback, both reach the desktop.


### PR DESCRIPTION
Offer to repair unreadable preferences after preserving the original file. Restoring defaults leaves guest files untouched and keeps sharing and port forwarding disabled.

Use the Windows folder picker for install locations and shared folders, matching the recovery controls.

Tested: preference preservation, write failures, guest-file preservation, Go race tests, vet, and Windows build. Visual checks remain pending.
