### PR TITLE
Fix clipboard reconnects and repeated copies

### DIFF
--- a/app/clipboard.go
+++ b/app/clipboard.go
@@ -3,33 +3,12 @@
 package main
 
 import (
-	"bufio"
-	"encoding/base64"
 	"fmt"
-	"io"
 	"net"
-	"strings"
-	"sync"
-	"time"
 )
 
-// Host side of the two-way text clipboard bridge, ported from
-// scripts/clipboard-bridge.ps1. The guest daemon (scripts/guest/
-// clipboard-bridge.sh, baked into the image) reaches these listeners as
-// 10.0.2.2 over QEMU user-mode networking:
-//   push port (4448): guest -> host, one base64(UTF-8) line per change, then close
-//   pull port (4449): host -> guest, one persistent connection, one line per change
-// Loop prevention: each side skips content it just received. Lines are LF-only;
-// CRLF corrupts the guest's base64 -d.
-
-type clipBridge struct {
-	mu       sync.Mutex
-	state    clipboardSyncState
-	pullConn net.Conn
-}
-
 func runClipboardBridge() {
-	b := &clipBridge{}
+	b := &clipBridge{getText: clipboardGetText, setText: clipboardSetText}
 	// These listeners double as the single-instance check: a second copy of
 	// the app (or a leftover QEMU on our QMP ports) must fail loudly, not
 	// die 30 seconds later with an inscrutable QEMU port error.
@@ -46,94 +25,4 @@ func runClipboardBridge() {
 	go b.acceptPush(push)
 	go b.acceptPull(pull)
 	go b.pollHost()
-}
-
-func (b *clipBridge) acceptPush(l net.Listener) {
-	for {
-		c, err := l.Accept()
-		if err != nil {
-			return
-		}
-		go func(c net.Conn) {
-			defer c.Close()
-			c.SetReadDeadline(time.Now().Add(3 * time.Second))
-			// A compromised or broken guest must not make the Windows launcher
-			// allocate an unbounded line. Base64 expands data by at most 4/3.
-			encodedLimit := int64((maxClipboardTextBytes+2)/3*4 + 2)
-			line, err := bufio.NewReader(io.LimitReader(c, encodedLimit)).ReadString('\n')
-			if err != nil || !strings.HasSuffix(line, "\n") {
-				return
-			}
-			line = strings.TrimRight(line, "\r\n")
-			data, err := base64.StdEncoding.DecodeString(line)
-			if err != nil || len(data) == 0 || len(data) > maxClipboardTextBytes {
-				return
-			}
-			text := string(data)
-			b.mu.Lock()
-			fresh := b.state.shouldAcceptGuest(text)
-			b.mu.Unlock()
-			if fresh {
-				if clipboardSetText(text) {
-					b.mu.Lock()
-					b.state.markGuestAccepted(text)
-					b.mu.Unlock()
-				} else {
-					logf("clipboard: could not open the Windows clipboard")
-				}
-			}
-		}(c)
-	}
-}
-
-func (b *clipBridge) acceptPull(l net.Listener) {
-	for {
-		c, err := l.Accept()
-		if err != nil {
-			return
-		}
-		b.mu.Lock()
-		if b.pullConn != nil {
-			b.pullConn.Close()
-		}
-		b.pullConn = c
-		b.mu.Unlock()
-		logf("clipboard: guest connected")
-		b.sendCurrentHost(c)
-	}
-}
-
-func (b *clipBridge) pollHost() {
-	for {
-		time.Sleep(400 * time.Millisecond)
-		b.mu.Lock()
-		conn := b.pullConn
-		b.mu.Unlock()
-		if conn != nil {
-			b.sendCurrentHost(conn)
-		}
-	}
-}
-
-func (b *clipBridge) sendCurrentHost(conn net.Conn) {
-	cur, ok := clipboardGetText()
-	if !ok || cur == "" {
-		return
-	}
-	line := base64.StdEncoding.EncodeToString([]byte(cur)) + "\n"
-
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.pullConn != conn || !b.state.shouldSendHost(cur) {
-		return
-	}
-	conn.SetWriteDeadline(time.Now().Add(3 * time.Second))
-	if _, err := conn.Write([]byte(line)); err != nil {
-		if b.pullConn == conn {
-			conn.Close()
-			b.pullConn = nil
-		}
-		return
-	}
-	b.state.markHostSent(cur)
 }

--- a/app/clipboard_bridge.go
+++ b/app/clipboard_bridge.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bufio"
+	"encoding/base64"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Host side of the two-way text clipboard bridge, ported from
+// scripts/clipboard-bridge.ps1. The guest daemon (scripts/guest/
+// clipboard-bridge.sh, baked into the image) reaches these listeners as
+// 10.0.2.2 over QEMU user-mode networking:
+//   push port (4448): guest -> host, one base64(UTF-8) line per change, then close
+//   pull port (4449): host -> guest, one persistent connection, one line per change
+// Loop prevention: each side skips content it just received. Lines are LF-only;
+// CRLF corrupts the guest's base64 -d.
+
+type clipBridge struct {
+	mu       sync.Mutex
+	state    clipboardSyncState
+	pullConn net.Conn
+	getText  func() (string, bool)
+	setText  func(string) bool
+}
+
+func (b *clipBridge) acceptPush(l net.Listener) {
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			return
+		}
+		go func(c net.Conn) {
+			defer c.Close()
+			c.SetReadDeadline(time.Now().Add(3 * time.Second))
+			// A compromised or broken guest must not make the Windows launcher
+			// allocate an unbounded line. Base64 expands data by at most 4/3.
+			encodedLimit := int64((maxClipboardTextBytes+2)/3*4 + 2)
+			line, err := bufio.NewReader(io.LimitReader(c, encodedLimit)).ReadString('\n')
+			if err != nil || !strings.HasSuffix(line, "\n") {
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			data, err := base64.StdEncoding.DecodeString(line)
+			if err != nil || len(data) == 0 || len(data) > maxClipboardTextBytes {
+				return
+			}
+			text := string(data)
+			b.acceptGuestText(text)
+		}(c)
+	}
+}
+
+func (b *clipBridge) acceptPull(l net.Listener) {
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			return
+		}
+		b.mu.Lock()
+		if b.pullConn != nil {
+			b.pullConn.Close()
+		}
+		b.pullConn = c
+		b.state = clipboardSyncState{}
+		b.mu.Unlock()
+		logf("clipboard: guest connected")
+		b.sendCurrentHost(c)
+	}
+}
+
+func (b *clipBridge) pollHost() {
+	for {
+		time.Sleep(400 * time.Millisecond)
+		b.mu.Lock()
+		conn := b.pullConn
+		b.mu.Unlock()
+		if conn != nil {
+			b.sendCurrentHost(conn)
+		}
+	}
+}
+
+func (b *clipBridge) sendCurrentHost(conn net.Conn) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.pullConn != conn {
+		return
+	}
+	cur, ok := b.getText()
+	if !ok || !b.state.shouldSendHost(cur) {
+		return
+	}
+	line := base64.StdEncoding.EncodeToString([]byte(cur)) + "\n"
+
+	conn.SetWriteDeadline(time.Now().Add(3 * time.Second))
+	if n, err := conn.Write([]byte(line)); err != nil || n != len(line) {
+		if b.pullConn == conn {
+			conn.Close()
+			b.pullConn = nil
+		}
+		return
+	}
+	b.state.markHostSent(cur)
+}
+
+// Serialize clipboard access with state changes so polling cannot echo a guest
+// write before it has been recorded, or deliver a stale host read afterward.
+func (b *clipBridge) acceptGuestText(text string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.state.shouldAcceptGuest(text) {
+		return
+	}
+	if b.setText(text) {
+		b.state.markGuestAccepted(text)
+	} else {
+		logf("clipboard: could not open the Windows clipboard")
+	}
+}

--- a/app/clipboard_bridge_test.go
+++ b/app/clipboard_bridge_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bufio"
+	"encoding/base64"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClipboardCanCopyPreviouslyReceivedTextAgain(t *testing.T) {
+	var state clipboardSyncState
+	state.markGuestAccepted("first")
+	state.markHostSent("second")
+	if !state.shouldSendHost("first") {
+		t.Fatal("recopied text was suppressed")
+	}
+}
+
+func TestClipboardRejectsUnrepresentableWindowsText(t *testing.T) {
+	for _, text := range []string{"", "a\x00b", "\xff"} {
+		if clipboardTextAllowed(text) {
+			t.Fatalf("accepted %q", text)
+		}
+	}
+	if !clipboardTextAllowed("こんにちは\n\n") {
+		t.Fatal("valid Unicode rejected")
+	}
+}
+
+func TestClipboardFailedGuestWriteCanRetry(t *testing.T) {
+	calls := 0
+	b := &clipBridge{setText: func(string) bool { calls++; return calls > 1 }}
+	b.acceptGuestText("retry me")
+	b.acceptGuestText("retry me")
+	b.acceptGuestText("retry me")
+	if calls != 2 {
+		t.Fatalf("got %d writes", calls)
+	}
+}
+
+func TestClipboardFailedHostWriteCanRetry(t *testing.T) {
+	host, guest := net.Pipe()
+	guest.Close()
+	b := &clipBridge{pullConn: host, getText: func() (string, bool) { return "retry me", true }}
+	b.sendCurrentHost(host)
+	if b.pullConn != nil || !b.state.shouldSendHost("retry me") {
+		t.Fatal("failed write consumed clipboard")
+	}
+	host, guest = net.Pipe()
+	defer host.Close()
+	defer guest.Close()
+	b.pullConn = host
+	done := make(chan struct{})
+	go func() { b.sendCurrentHost(host); close(done) }()
+	guest.SetReadDeadline(time.Now().Add(time.Second))
+	line, err := bufio.NewReader(guest).ReadString('\n')
+	if err != nil || line != base64.StdEncoding.EncodeToString([]byte("retry me"))+"\n" {
+		t.Fatalf("got %q, %v", line, err)
+	}
+	<-done
+	if b.state.shouldSendHost("retry me") {
+		t.Fatal("successful delivery not recorded")
+	}
+}
+
+func TestClipboardReconnectReceivesCurrentHostText(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	const value = "current clipboard\n\n"
+	b := &clipBridge{getText: func() (string, bool) { return value, true }}
+	done := make(chan struct{})
+	go func() { b.acceptPull(listener); close(done) }()
+	for i := 0; i < 2; i++ {
+		c, err := net.Dial("tcp", listener.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.SetReadDeadline(time.Now().Add(time.Second))
+		line, err := bufio.NewReader(c).ReadString('\n')
+		c.Close()
+		if err != nil || line != base64.StdEncoding.EncodeToString([]byte(value))+"\n" {
+			t.Fatalf("connection %d: %q %v", i, line, err)
+		}
+	}
+	listener.Close()
+	<-done
+	b.mu.Lock()
+	b.pullConn.Close()
+	b.mu.Unlock()
+}
+
+func TestClipboardGuestWriteAndHostPollAreSerialized(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	current := "old host text"
+	b := &clipBridge{setText: func(s string) bool { close(entered); <-release; current = s; return true }, getText: func() (string, bool) { return current, true }}
+	host, guest := net.Pipe()
+	defer host.Close()
+	defer guest.Close()
+	b.pullConn = host
+	accepted, polled := make(chan struct{}), make(chan struct{})
+	go func() { b.acceptGuestText("guest text"); close(accepted) }()
+	<-entered
+	go func() { b.sendCurrentHost(host); close(polled) }()
+	close(release)
+	<-accepted
+	select {
+	case <-polled:
+	case <-time.After(time.Second):
+		t.Fatal("guest clipboard echoed to host connection")
+	}
+}
+
+func TestClipboardPushPreservesTextAndRejectsMalformedFrames(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	got := make(chan string, 8)
+	b := &clipBridge{setText: func(s string) bool { got <- s; return true }}
+	done := make(chan struct{})
+	go func() { b.acceptPush(listener); close(done) }()
+	for _, frame := range []string{"not base64\n", base64.StdEncoding.EncodeToString([]byte("no terminator")), base64.StdEncoding.EncodeToString([]byte("a\x00b")) + "\n", base64.StdEncoding.EncodeToString([]byte("valid\n\n")) + "\n"} {
+		c, err := net.Dial("tcp", listener.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.Write([]byte(frame))
+		c.Close()
+	}
+	select {
+	case value := <-got:
+		if value != "valid\n\n" {
+			t.Fatalf("got %q", value)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("valid clipboard not delivered")
+	}
+	listener.Close()
+	<-done
+}
+
+func TestClipboardSkipsOversizedHostBeforeEncoding(t *testing.T) {
+	host, guest := net.Pipe()
+	defer host.Close()
+	defer guest.Close()
+	b := &clipBridge{pullConn: host, getText: func() (string, bool) { return strings.Repeat("x", maxClipboardTextBytes+1), true }}
+	b.sendCurrentHost(host)
+	if b.state.lastSeen != "" {
+		t.Fatal("oversized text recorded")
+	}
+}

--- a/app/clipboard_state.go
+++ b/app/clipboard_state.go
@@ -1,17 +1,21 @@
 package main
 
+import (
+	"strings"
+	"unicode/utf8"
+)
+
 const maxClipboardTextBytes = 8 << 20
 
 func clipboardTextAllowed(text string) bool {
-	return len(text) > 0 && len(text) <= maxClipboardTextBytes
+	return len(text) > 0 && len(text) <= maxClipboardTextBytes && utf8.ValidString(text) && !strings.ContainsRune(text, 0)
 }
 
 // clipboardSyncState tracks content that already crossed the bridge. Host
 // content is marked only after a successful write so a disconnected or
 // reconnecting guest cannot make a clipboard change disappear.
 type clipboardSyncState struct {
-	lastSeen      string
-	lastFromGuest string
+	lastSeen string
 }
 
 func (s *clipboardSyncState) shouldAcceptGuest(text string) bool {
@@ -19,12 +23,11 @@ func (s *clipboardSyncState) shouldAcceptGuest(text string) bool {
 }
 
 func (s *clipboardSyncState) markGuestAccepted(text string) {
-	s.lastFromGuest = text
 	s.lastSeen = text
 }
 
 func (s *clipboardSyncState) shouldSendHost(text string) bool {
-	return clipboardTextAllowed(text) && text != s.lastSeen && text != s.lastFromGuest
+	return clipboardTextAllowed(text) && text != s.lastSeen
 }
 
 func (s *clipboardSyncState) markHostSent(text string) {

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -39,8 +39,9 @@ personal details. Do not upload the guest disk or a full backup.
 - [ ] GPU rendering, then CPU fallback, both reach the desktop.
 - [ ] Keyboard and Windows key work only in the intended window; host shortcuts
   still work after switching away. Windows handles Win+L itself.
-- [ ] Text clipboard works in both directions; shared files can be read and
-  written from both sides.
+- [ ] Text clipboard works in both directions, including Unicode, trailing
+  newlines, copying an earlier value again, and reconnecting after a guest reboot.
+- [ ] Shared files can be read and written from both sides.
 - [ ] Audio playback, device switching, and video work. Note microphone activity
   at idle and when an app starts and stops recording.
 - [ ] Resize, fullscreen, and movement between monitors with different scaling.

--- a/guest-build/0030-Preserve-clipboard-text-and-retry-failed-transfers.patch
+++ b/guest-build/0030-Preserve-clipboard-text-and-retry-failed-transfers.patch
@@ -1,0 +1,181 @@
+From 13441b027aa4a3ac3bdf1ed1b60e220b941fb71b Mon Sep 17 00:00:00 2001
+From: Try Omarchy Release <actions@users.noreply.github.com>
+Date: Fri, 4 Sep 2026 21:43:50 -0400
+Subject: [PATCH] Preserve clipboard text and retry failed transfers
+
+---
+ .../usr/local/bin/clipboard-bridge            | 35 +++++++----
+ guest/scripts/finalize-rootfs.sh              |  5 +-
+ guest/tests/test_clipboard.py                 | 59 +++++++++++++++++++
+ guest/tests/verify.py                         |  6 +-
+ 4 files changed, 91 insertions(+), 14 deletions(-)
+ create mode 100644 guest/tests/test_clipboard.py
+
+diff --git a/guest/factory-overlay/usr/local/bin/clipboard-bridge b/guest/factory-overlay/usr/local/bin/clipboard-bridge
+index 0acdb78..2cc7698 100755
+--- a/guest/factory-overlay/usr/local/bin/clipboard-bridge
++++ b/guest/factory-overlay/usr/local/bin/clipboard-bridge
+@@ -12,6 +12,24 @@ export XDG_RUNTIME_DIR STATE
+ umask 077
+ mkdir -p "$STATE"
+ 
++# wl-paste supplies the selected text on stdin. Keeping it in a file preserves
++# trailing newlines and avoids a second clipboard read after the selection moves.
++if [ "${1:-}" = --push ]; then
++  outgoing=$(mktemp "$STATE/outgoing.XXXXXX") || exit 1
++  trap 'rm -f "$outgoing"' EXIT
++  head -c 8388609 > "$outgoing" || exit 1
++  size=$(wc -c < "$outgoing")
++  [ "$size" -gt 0 ] && [ "$size" -le 8388608 ] || exit 0
++  sha=$(sha256sum < "$outgoing" | cut -d' ' -f1)
++  [ "$sha" = "$(cat "$STATE/last_content" 2>/dev/null)" ] && exit 0
++  if { base64 -w0 < "$outgoing"; echo; } | socat -u - TCP:$HOST:$PUSH_PORT,connect-timeout=3 2>/dev/null; then
++    printf '%s\n' "$sha" > "$STATE/last_content"
++  else
++    exit 1
++  fi
++  exit 0
++fi
++
+ find_wayland() {
+   if [ -n "${WAYLAND_DISPLAY:-}" ] && [ -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; then
+     export WAYLAND_DISPLAY
+@@ -57,8 +75,11 @@ while :; do
+       socat -u TCP:$HOST:$PULL_PORT,connect-timeout=3 - 2>/dev/null | while IFS= read -r line; do
+         line=${line%"$(printf '\r')"}
+         printf '%s' "$line" | base64 -d > "$STATE/incoming" 2>/dev/null || continue
+-        sha256sum < "$STATE/incoming" | cut -d' ' -f1 > "$STATE/last_set"
+-        wl-copy < "$STATE/incoming" || break
++        sha256sum < "$STATE/incoming" | cut -d' ' -f1 > "$STATE/last_content"
++        if ! wl-copy < "$STATE/incoming"; then
++          rm -f "$STATE/last_content"
++          break
++        fi
+       done
+       sleep 2
+     done
+@@ -67,15 +88,7 @@ while :; do
+ 
+   # guest -> host. wl-paste exits when its Wayland connection disappears, so
+   # the outer loop can discover the replacement socket and restart both sides.
+-  wl-paste --no-newline --watch sh -c '
+-    cur=$(wl-paste --no-newline 2>/dev/null) || exit 0
+-    [ -z "$cur" ] && exit 0
+-    sha=$(printf "%s" "$cur" | sha256sum | cut -d" " -f1)
+-    [ "$sha" = "$(cat "$STATE/last_set" 2>/dev/null)" ] && exit 0
+-    [ "$sha" = "$(cat "$STATE/last_sent" 2>/dev/null)" ] && exit 0
+-    echo "$sha" > "$STATE/last_sent"
+-    { printf "%s" "$cur" | base64 -w0; echo; } | socat -u - TCP:10.0.2.2:4448,connect-timeout=3 2>/dev/null
+-  ' || true
++  wl-paste --type text --watch "$0" --push || true
+ 
+ 	cleanup
+   sleep 2
+diff --git a/guest/scripts/finalize-rootfs.sh b/guest/scripts/finalize-rootfs.sh
+index 2ff28c9..f342eaa 100755
+--- a/guest/scripts/finalize-rootfs.sh
++++ b/guest/scripts/finalize-rootfs.sh
+@@ -54,6 +54,9 @@ update-desktop-database /usr/share/applications || true
+ # export, lifecycle, and readiness behavior without touching user data or
+ # attempting a full package upgrade.
+ compat_paths=(
++  etc/systemd/user/clipboard-bridge.service
++  etc/systemd/user/graphical-session.target.wants/clipboard-bridge.service
++  usr/local/bin/clipboard-bridge
+   etc/systemd/system/try-omarchy-ready.service
+   etc/systemd/system/multi-user.target.wants/try-omarchy-ready.service
+   etc/systemd/system/try-omarchy-sshd.service
+@@ -76,7 +79,7 @@ kernel_release=$(find /usr/lib/modules -mindepth 1 -maxdepth 1 -type d -printf '
+ }
+ # Bump this revision whenever compat-overlay.tar changes in a way that must be
+ # applied to persistent disks created by an earlier launcher release.
+-compat_revision=3
++compat_revision=4
+ printf '%s:%s\n' "$compat_revision" "$kernel_release" >/usr/share/try-omarchy/compat-version
+ 
+ # Never let the container host's hardware autodetection remove the virtual
+diff --git a/guest/tests/test_clipboard.py b/guest/tests/test_clipboard.py
+new file mode 100644
+index 0000000..2ae5994
+--- /dev/null
++++ b/guest/tests/test_clipboard.py
+@@ -0,0 +1,59 @@
++import base64
++import hashlib
++import os
++from pathlib import Path
++import subprocess
++import tempfile
++import unittest
++
++BRIDGE = Path(__file__).resolve().parents[1] / 'factory-overlay/usr/local/bin/clipboard-bridge'
++
++
++class ClipboardTests(unittest.TestCase):
++    def setUp(self):
++        self.tmp = tempfile.TemporaryDirectory()
++        self.addCleanup(self.tmp.cleanup)
++        self.root = Path(self.tmp.name)
++        self.bin = self.root / 'bin'
++        self.bin.mkdir()
++        self.capture = self.root / 'capture'
++        self.env = dict(os.environ, XDG_RUNTIME_DIR=str(self.root),
++                        PATH=str(self.bin) + os.pathsep + os.environ['PATH'],
++                        CAPTURE=str(self.capture))
++        self.socat('cat >> "$CAPTURE"')
++
++    def socat(self, body):
++        path = self.bin / 'socat'
++        path.write_text('#!/bin/sh\n' + body + '\n')
++        path.chmod(0o755)
++
++    def push(self, data):
++        return subprocess.run(['sh', str(BRIDGE), '--push'], input=data,
++                              env=self.env, capture_output=True, timeout=10)
++
++    def test_preserves_unicode_and_trailing_newlines(self):
++        data = 'こんにちは\n\n'.encode()
++        self.assertEqual(self.push(data).returncode, 0)
++        self.assertEqual(self.capture.read_bytes(), base64.b64encode(data) + b'\n')
++        self.assertEqual(self.push(data).returncode, 0)
++        self.assertEqual(self.capture.read_bytes(), base64.b64encode(data) + b'\n')
++
++    def test_failed_send_can_be_retried(self):
++        self.socat('cat > /dev/null; exit 1')
++        self.assertNotEqual(self.push(b'retry').returncode, 0)
++        self.socat('cat >> "$CAPTURE"')
++        self.assertEqual(self.push(b'retry').returncode, 0)
++        self.assertEqual(self.capture.read_bytes(), base64.b64encode(b'retry') + b'\n')
++
++    def test_previous_text_can_be_copied_after_host_change(self):
++        self.push(b'first')
++        state = self.root / 'try-omarchy-clipboard/last_content'
++        state.write_text(hashlib.sha256(b'host change').hexdigest() + '\n')
++        self.push(b'first')
++        self.assertEqual(self.capture.read_bytes(), (base64.b64encode(b'first') + b'\n') * 2)
++
++    def test_empty_and_oversized_text_are_ignored(self):
++        self.assertEqual(self.push(b'').returncode, 0)
++        self.assertEqual(self.push(b'x' * (8388608 + 1)).returncode, 0)
++        self.assertFalse(self.capture.exists())
++        self.assertEqual(list((self.root / 'try-omarchy-clipboard').glob('outgoing.*')), [])
+diff --git a/guest/tests/verify.py b/guest/tests/verify.py
+index 50ee629..758596d 100755
+--- a/guest/tests/verify.py
++++ b/guest/tests/verify.py
+@@ -252,8 +252,10 @@ def main() -> None:
+ 
+     finalize_rootfs = read(GUEST / "scripts/finalize-rootfs.sh")
+     check(
+-        "compat_revision=3" in finalize_rootfs
+-        and "compat_revision" in finalize_rootfs.split("compat-version")[0],
++        "compat_revision=4" in finalize_rootfs
++        and "compat_revision" in finalize_rootfs.split("compat-version")[0]
++        and "usr/local/bin/clipboard-bridge" in finalize_rootfs
++        and "etc/systemd/user/graphical-session.target.wants/clipboard-bridge.service" in finalize_rootfs,
+         "launcher integration has an explicit revision for persistent-disk upgrades",
+     )
+ 
+-- 
+2.55.0
+

--- a/scripts/guest/clipboard-bridge.sh
+++ b/scripts/guest/clipboard-bridge.sh
@@ -12,6 +12,24 @@ export XDG_RUNTIME_DIR STATE
 umask 077
 mkdir -p "$STATE"
 
+# wl-paste supplies the selected text on stdin. Keeping it in a file preserves
+# trailing newlines and avoids a second clipboard read after the selection moves.
+if [ "${1:-}" = --push ]; then
+  outgoing=$(mktemp "$STATE/outgoing.XXXXXX") || exit 1
+  trap 'rm -f "$outgoing"' EXIT
+  head -c 8388609 > "$outgoing" || exit 1
+  size=$(wc -c < "$outgoing")
+  [ "$size" -gt 0 ] && [ "$size" -le 8388608 ] || exit 0
+  sha=$(sha256sum < "$outgoing" | cut -d' ' -f1)
+  [ "$sha" = "$(cat "$STATE/last_content" 2>/dev/null)" ] && exit 0
+  if { base64 -w0 < "$outgoing"; echo; } | socat -u - TCP:$HOST:$PUSH_PORT,connect-timeout=3 2>/dev/null; then
+    printf '%s\n' "$sha" > "$STATE/last_content"
+  else
+    exit 1
+  fi
+  exit 0
+fi
+
 find_wayland() {
   if [ -n "${WAYLAND_DISPLAY:-}" ] && [ -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; then
     export WAYLAND_DISPLAY
@@ -57,8 +75,11 @@ while :; do
       socat -u TCP:$HOST:$PULL_PORT,connect-timeout=3 - 2>/dev/null | while IFS= read -r line; do
         line=${line%"$(printf '\r')"}
         printf '%s' "$line" | base64 -d > "$STATE/incoming" 2>/dev/null || continue
-        sha256sum < "$STATE/incoming" | cut -d' ' -f1 > "$STATE/last_set"
-        wl-copy < "$STATE/incoming" || break
+        sha256sum < "$STATE/incoming" | cut -d' ' -f1 > "$STATE/last_content"
+        if ! wl-copy < "$STATE/incoming"; then
+          rm -f "$STATE/last_content"
+          break
+        fi
       done
       sleep 2
     done
@@ -67,16 +88,8 @@ while :; do
 
   # guest -> host. wl-paste exits when its Wayland connection disappears, so
   # the outer loop can discover the replacement socket and restart both sides.
-  wl-paste --no-newline --watch sh -c '
-    cur=$(wl-paste --no-newline 2>/dev/null) || exit 0
-    [ -z "$cur" ] && exit 0
-    sha=$(printf "%s" "$cur" | sha256sum | cut -d" " -f1)
-    [ "$sha" = "$(cat "$STATE/last_set" 2>/dev/null)" ] && exit 0
-    [ "$sha" = "$(cat "$STATE/last_sent" 2>/dev/null)" ] && exit 0
-    echo "$sha" > "$STATE/last_sent"
-    { printf "%s" "$cur" | base64 -w0; echo; } | socat -u - TCP:10.0.2.2:4448,connect-timeout=3 2>/dev/null
-  ' || true
+  wl-paste --type text --watch "$0" --push || true
 
 	cleanup
-	sleep 2
+  sleep 2
 done


### PR DESCRIPTION
Clipboard sync now handles reconnects and copying an earlier value again. Guest copies preserve trailing newlines, and failed sends can be retried. Existing guest disks receive the updated bridge with the next guest payload.

Checked with Go race tests, Windows cross-build and vet, and guest contract tests. Windows desktop and VM checks remain pending.
