### PR TITLE
Preserve portable guest data during reset

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -132,7 +132,7 @@ func main() {
 	flag.StringVar(&cfg.dir, "dir", defaultDir, "Try Omarchy data directory (virtual machine, runtime, and settings)")
 	flag.StringVar(&cfg.winqEmu, "winq", `C:\WINQ-EMU`, "WINQ-EMU install path (GPU mode)")
 	flag.StringVar(&cfg.share, "share", "", "Windows folder shared into Omarchy at /mnt/host and as ~/<folder name>")
-	flag.BoolVar(&cfg.fresh, "fresh", false, "discard the writable disk and start over")
+	flag.BoolVar(&cfg.fresh, "fresh", false, "start over and retain the previous writable disk for recovery")
 	flag.BoolVar(&cfg.fullscreen, "fullscreen", false, "start fullscreen (Immersive)")
 	flag.IntVar(&cfg.memOverrideMiB, "memory", 0, "guest RAM in MiB (default: sized to this PC)")
 	flag.IntVar(&cfg.diskGiB, "disk-size", 0, "guest disk capacity in GiB (0: default; grows existing standard disks, never shrinks)")

--- a/app/qemu.go
+++ b/app/qemu.go
@@ -151,15 +151,8 @@ func prepareDisk(cfg *config, expandedMiB int64) error {
 		_, err := resetStandardDisk(cfg, expandedMiB)
 		return err
 	}
-	if cfg.fresh {
-		if err := os.Remove(cfg.disk); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("discarding the existing disk: %w", err)
-		}
-		if cfg.portable {
-			if err := os.Remove(portableBackingStatePath(cfg.disk)); err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("discarding the portable disk identity: %w", err)
-			}
-		}
+	if cfg.fresh && cfg.portable {
+		return resetPortableDisk(cfg, expandedBytes)
 	}
 	if cfg.portable {
 		return preparePortableDisk(cfg, expandedBytes)

--- a/app/reset_portable.go
+++ b/app/reset_portable.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Portable disks and their backing identities travel together. Publish the
+// identity before its new disk; an interruption must never pair an old disk
+// with the replacement factory's identity.
+func resetPortableDisk(cfg *config, expandedBytes int64) error {
+	existing := make([]string, 0, 2)
+	for _, path := range []string{cfg.disk, portableBackingStatePath(cfg.disk)} {
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("reset requires regular disk and identity files: %s", path)
+		}
+		existing = append(existing, path)
+	}
+	if len(existing) == 0 {
+		return preparePortableDisk(cfg, expandedBytes)
+	}
+	var lock *os.File
+	if existing[0] == cfg.disk {
+		var err error
+		lock, err = openBackupDisk(cfg.disk)
+		if err != nil {
+			return fmt.Errorf("close Omarchy before resetting: %w", err)
+		}
+		defer lock.Close()
+	}
+	stage, err := os.MkdirTemp(cfg.vmDir, ".reset-staging-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(stage)
+	next := *cfg
+	next.fresh = false
+	next.vmDir = stage
+	next.disk = filepath.Join(stage, filepath.Base(cfg.disk))
+	if err := preparePortableDisk(&next, expandedBytes); err != nil {
+		return err
+	}
+	if err := checkSetupCancelled(); err != nil {
+		return err
+	}
+	retained, err := os.MkdirTemp(cfg.vmDir, "before-reset-*")
+	if err != nil {
+		return err
+	}
+	if lock != nil {
+		if err := lock.Close(); err != nil {
+			os.Remove(retained)
+			return err
+		}
+	}
+	moves := make([]resetMove, 0, 4)
+	for _, path := range existing {
+		moves = append(moves, resetMove{path, filepath.Join(retained, filepath.Base(path))})
+	}
+	moves = append(moves,
+		resetMove{portableBackingStatePath(next.disk), portableBackingStatePath(cfg.disk)},
+		resetMove{next.disk, cfg.disk},
+	)
+	if err := publishPortableReset(moves, os.Rename); err != nil {
+		_ = os.Remove(retained) // Only remove an empty folder after successful rollback.
+		return fmt.Errorf("portable reset failed; retained files, if any, are in %s: %w", retained, err)
+	}
+	logf("previous portable disk retained in %s", retained)
+	return nil
+}
+
+type resetMove struct{ from, to string }
+
+func publishPortableReset(moves []resetMove, rename func(string, string) error) error {
+	for i, move := range moves {
+		if err := rename(move.from, move.to); err != nil {
+			for j := i - 1; j >= 0; j-- {
+				undo := moves[j]
+				if rollbackErr := rename(undo.to, undo.from); rollbackErr != nil {
+					// Stop here. Restoring an older disk while the new identity remains
+					// active would make a mismatched backing image appear trustworthy.
+					return fmt.Errorf("%v; could not restore %s: %w", err, undo.to, rollbackErr)
+				}
+			}
+			return err
+		}
+	}
+	return nil
+}

--- a/app/reset_portable_test.go
+++ b/app/reset_portable_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func portableResetFixture(t *testing.T) *config {
+	t.Helper()
+	cfg := resetFixture(t)
+	cfg.portable = true
+	cfg.diskFormat = "qcow2"
+	cfg.disk = filepath.Join(cfg.vmDir, "disk.qcow2")
+	if err := os.WriteFile(cfg.disk, []byte("personal USB files"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePortableBackingState(cfg.disk, testSHA256([]byte("older factory"))); err != nil {
+		t.Fatal(err)
+	}
+	writePortableGuestReceipt(t, cfg.guestDir, []byte("new factory"))
+	cfg.fresh = true
+	return cfg
+}
+
+func TestPortableResetRetainsDiskAndIdentity(t *testing.T) {
+	cfg := portableResetFixture(t)
+	oldIdentity, err := os.ReadFile(portableBackingStatePath(cfg.disk))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareDisk(cfg, 1); err != nil {
+		t.Fatal(err)
+	}
+	retained, err := filepath.Glob(filepath.Join(cfg.vmDir, "before-reset-*", "disk.qcow2"))
+	if err != nil || len(retained) != 1 {
+		t.Fatalf("retained: %v %v", retained, err)
+	}
+	old, err := os.ReadFile(retained[0])
+	if err != nil || string(old) != "personal USB files" {
+		t.Fatalf("previous disk: %q %v", old, err)
+	}
+	identity, err := os.ReadFile(portableBackingStatePath(retained[0]))
+	if err != nil || !bytes.Equal(identity, oldIdentity) {
+		t.Fatalf("previous identity: %q %v", identity, err)
+	}
+	if ok, err := qcow2OverlayMatches(cfg.disk, "../guest/rootfs.ext4", 1<<20); err != nil || !ok {
+		t.Fatalf("replacement disk: %t %v", ok, err)
+	}
+	if ok, err := portableBackingStateMatches(cfg.disk, testSHA256([]byte("new factory"))); err != nil || !ok {
+		t.Fatalf("replacement identity: %t %v", ok, err)
+	}
+}
+
+func TestPortableResetFailureKeepsOldPair(t *testing.T) {
+	for _, mode := range []string{"missing-receipt", "cancelled", "invalid-size", "locked"} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := portableResetFixture(t)
+			size := int64(1)
+			var lock *os.File
+			switch mode {
+			case "missing-receipt":
+				os.RemoveAll(cfg.guestDir)
+			case "cancelled":
+				requestSetupCancel()
+				t.Cleanup(func() { configureSetupCancellation(false) })
+			case "invalid-size":
+				size = -1
+			case "locked":
+				var err error
+				lock, err = openBackupDisk(cfg.disk)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer lock.Close()
+			}
+			if err := prepareDisk(cfg, size); err == nil {
+				t.Fatal("reset unexpectedly succeeded")
+			}
+			if lock != nil {
+				lock.Close()
+			}
+			old, err := os.ReadFile(cfg.disk)
+			if err != nil || string(old) != "personal USB files" {
+				t.Fatalf("previous disk changed: %q %v", old, err)
+			}
+			if ok, err := portableBackingStateMatches(cfg.disk, testSHA256([]byte("older factory"))); err != nil || !ok {
+				t.Fatalf("previous identity changed: %t %v", ok, err)
+			}
+		})
+	}
+}
+
+func TestPortableResetHandlesMissingDiskOrIdentity(t *testing.T) {
+	for _, missing := range []string{"disk", "identity"} {
+		t.Run(missing, func(t *testing.T) {
+			cfg := portableResetFixture(t)
+			path := cfg.disk
+			if missing == "identity" {
+				path = portableBackingStatePath(cfg.disk)
+			}
+			if err := os.Remove(path); err != nil {
+				t.Fatal(err)
+			}
+			if err := prepareDisk(cfg, 1); err != nil {
+				t.Fatal(err)
+			}
+			if ok, err := portableBackingStateMatches(cfg.disk, testSHA256([]byte("new factory"))); err != nil || !ok {
+				t.Fatalf("replacement identity: %t %v", ok, err)
+			}
+		})
+	}
+}
+
+func TestPortableResetRollsBackEveryPublicationFailure(t *testing.T) {
+	for fail := 0; fail < 4; fail++ {
+		t.Run(string(rune('0'+fail)), func(t *testing.T) {
+			root := t.TempDir()
+			disk, identity, newDisk, newIdentity, oldDisk, oldIdentity := filepath.Join(root, "disk"), filepath.Join(root, "identity"), filepath.Join(root, "new-disk"), filepath.Join(root, "new-identity"), filepath.Join(root, "old-disk"), filepath.Join(root, "old-identity")
+			for path, value := range map[string]string{disk: "old disk", identity: "old identity", newDisk: "new disk", newIdentity: "new identity"} {
+				if err := os.WriteFile(path, []byte(value), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			moves := []resetMove{{disk, oldDisk}, {identity, oldIdentity}, {newIdentity, identity}, {newDisk, disk}}
+			count := 0
+			err := publishPortableReset(moves, func(from, to string) error {
+				count++
+				if count == fail+1 {
+					return errors.New("publication failed")
+				}
+				return os.Rename(from, to)
+			})
+			if err == nil {
+				t.Fatal("expected failure")
+			}
+			for path, want := range map[string]string{disk: "old disk", identity: "old identity"} {
+				got, err := os.ReadFile(path)
+				if err != nil || string(got) != want {
+					t.Fatalf("%s: %q %v", path, got, err)
+				}
+			}
+		})
+	}
+}
+
+func TestPortableResetFailedRollbackDoesNotPublishMismatchedPair(t *testing.T) {
+	root := t.TempDir()
+	disk, identity, newDisk, newIdentity, oldDisk, oldIdentity := filepath.Join(root, "disk"), filepath.Join(root, "identity"), filepath.Join(root, "new-disk"), filepath.Join(root, "new-identity"), filepath.Join(root, "old-disk"), filepath.Join(root, "old-identity")
+	for path, value := range map[string]string{disk: "old disk", identity: "old identity", newDisk: "new disk", newIdentity: "new identity"} {
+		if err := os.WriteFile(path, []byte(value), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	err := publishPortableReset([]resetMove{{disk, oldDisk}, {identity, oldIdentity}, {newIdentity, identity}, {newDisk, disk}}, func(from, to string) error {
+		if from == newDisk || from == identity && to == newIdentity {
+			return errors.New("file is locked")
+		}
+		return os.Rename(from, to)
+	})
+	if err == nil || !strings.Contains(err.Error(), identity) {
+		t.Fatalf("missing recovery error: %v", err)
+	}
+	if _, err := os.Stat(disk); !os.IsNotExist(err) {
+		t.Fatal("old disk exposed with replacement identity")
+	}
+	for path, want := range map[string]string{oldDisk: "old disk", oldIdentity: "old identity"} {
+		got, err := os.ReadFile(path)
+		if err != nil || string(got) != want {
+			t.Fatalf("lost retained file: %q %v", got, err)
+		}
+	}
+}

--- a/docs/PORTABLE_USB.md
+++ b/docs/PORTABLE_USB.md
@@ -70,3 +70,10 @@ TryOmarchy.exe -portable
 Shut Omarchy down from its system menu and wait for the QEMU window to close
 before ejecting the drive. To reset only the writable guest state, start with
 `-portable -fresh`; the authenticated factory image and payload remain intact.
+
+Development builds prepare the replacement before moving the previous disk and
+its `.backing-sha256` file into `vm/before-reset-*`. A failed reset rolls those
+files back when possible. If Windows prevents rollback, the error identifies
+the retained folder. Keep both files and the matching original factory payload
+for recovery. A retained QCOW2 disk must be returned to the `vm` folder before
+use because its factory path is relative to that folder.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -77,6 +77,11 @@ Use the copied guest for interruption and low-space tests.
 - [ ] Configuration export restores the selected theme, personal configuration,
   and added packages on a separate fresh Omarchy installation.
 
+- [ ] In portable mode, reset with `-portable -fresh`, reach a new guest, and
+  verify that `vm/before-reset-*` retains the previous QCOW2 disk and identity.
+  With Omarchy closed and the matching original factory payload restored,
+  returning that retained pair to `vm` should recover the previous guest.
+
 ## Coverage
 
 Track results for Intel and AMD CPUs, integrated and discrete Intel/AMD/NVIDIA


### PR DESCRIPTION
Portable reset now prepares the new disk before retaining the old disk and its backing identity in a recovery folder. Publication failures roll back the pair when possible and report the retained location otherwise.

Checked with Go race tests, Windows cross-build and vet, and failure tests for each publication step. Booting a retained USB guest still needs a manual check.
