### PR TITLE
Reuse completed downloads after interrupted setup

### DIFF
--- a/app/download.go
+++ b/app/download.go
@@ -92,6 +92,19 @@ func downloadVerifiedWithOptions(client *http.Client, url, dest, wantSum string,
 		}
 		attempt++
 	}
+	// A previous run may have finished transferring before it was interrupted
+	// during verification or publication. Recover that file even if the server
+	// is currently unavailable. Hash only once, after retries, so incomplete
+	// multi-gigabyte downloads do not get rehashed on every network failure.
+	if size, err := partialFileSize(dest + ".part"); err == nil && size > 0 {
+		ok, err := verifyAndCommitPart(dest+".part", dest, wantSum, progress)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+	}
 	return fmt.Errorf("download failed after %d attempts: %w", opts.maxAttempts, lastErr)
 }
 
@@ -126,6 +139,17 @@ func downloadAttempt(client *http.Client, url, dest, wantSum string, progress do
 	total := resp.ContentLength
 	switch resp.StatusCode {
 	case http.StatusOK:
+		// A complete cached transfer needs verification, not another download,
+		// even when the server ignores Range. A wrong hash still restarts below.
+		if offset > 0 && offset == resp.ContentLength {
+			ok, err := verifyAndCommitPart(tmp, dest, wantSum, progress)
+			if err != nil {
+				return false, false, err
+			}
+			if ok {
+				return false, false, nil
+			}
+		}
 		// The server ignored Range. Restart safely using this full response.
 		offset = 0
 	case http.StatusPartialContent:
@@ -346,10 +370,17 @@ func copyDownloadBody(body io.ReadCloser, dst io.Writer, offset, total int64, pr
 		}
 		n, readErr := body.Read(buf)
 		if n > 0 {
-			if _, err := dst.Write(buf[:n]); err != nil {
+			if total >= 0 && int64(n) > total-offset-written {
+				return written, false, fmt.Errorf("download exceeded its expected size")
+			}
+			count, err := dst.Write(buf[:n])
+			written += int64(count)
+			if err != nil {
 				return written, false, err
 			}
-			written += int64(n)
+			if count != n {
+				return written, false, io.ErrShortWrite
+			}
 			if activity != nil {
 				select {
 				case activity <- struct{}{}:

--- a/app/download_test.go
+++ b/app/download_test.go
@@ -534,3 +534,121 @@ func TestParseContentRange(t *testing.T) {
 		}
 	}
 }
+
+func TestDownloadRecoversCompleteCacheWhenServerUnavailable(t *testing.T) {
+	configureSetupCancellation(false)
+	payload := []byte("complete authenticated payload")
+	for _, offline := range []bool{false, true} {
+		t.Run(strconv.FormatBool(offline), func(t *testing.T) {
+			client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				if offline {
+					return nil, errors.New("network unavailable")
+				}
+				return &http.Response{StatusCode: http.StatusServiceUnavailable, Body: io.NopCloser(strings.NewReader("busy")), Header: make(http.Header)}, nil
+			})}
+			runTestDownload(t, client, "https://example.invalid/payload", payload, func(dest string) {
+				if err := os.WriteFile(dest+".part", payload, 0600); err != nil {
+					t.Fatal(err)
+				}
+			})
+		})
+	}
+}
+
+func TestDownloadLeavesIncompleteCacheWhenServerUnavailable(t *testing.T) {
+	configureSetupCancellation(false)
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) { return nil, errors.New("network unavailable") })}
+	dest := filepath.Join(t.TempDir(), "payload")
+	if err := os.WriteFile(dest+".part", []byte("prefix"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	err := downloadVerifiedWithOptions(client, "https://example.invalid/payload", dest, testSHA256([]byte("prefix and remainder")), nil, fastDownloadOptions())
+	if err == nil {
+		t.Fatal("incomplete cache accepted")
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatal("incomplete payload published")
+	}
+	data, err := os.ReadFile(dest + ".part")
+	if err != nil || string(data) != "prefix" {
+		t.Fatalf("partial lost: %q %v", data, err)
+	}
+}
+
+type unreadDownloadBody struct{ t *testing.T }
+
+func (b unreadDownloadBody) Read([]byte) (int, error) {
+	b.t.Error("complete cache was downloaded again")
+	return 0, io.EOF
+}
+func (unreadDownloadBody) Close() error { return nil }
+
+func TestDownloadChecksCompleteCacheWhenRangeIgnored(t *testing.T) {
+	payload := []byte("already here")
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, ContentLength: int64(len(payload)), Body: unreadDownloadBody{t}, Header: make(http.Header)}, nil
+	})}
+	runTestDownload(t, client, "https://example.invalid/payload", payload, func(dest string) {
+		if err := os.WriteFile(dest+".part", payload, 0600); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestDownloadReplacesWrongSameSizeCache(t *testing.T) {
+	payload := []byte("right")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Header().Set("Content-Length", "5"); w.Write(payload) }))
+	defer server.Close()
+	runTestDownload(t, server.Client(), server.URL, payload, func(dest string) {
+		if err := os.WriteFile(dest+".part", []byte("wrong"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+type shortDownloadWriter struct{}
+
+func (shortDownloadWriter) Write(p []byte) (int, error) { return len(p) - 1, nil }
+
+func TestDownloadReportsShortDiskWrite(t *testing.T) {
+	configureSetupCancellation(false)
+	written, retry, err := copyDownloadBody(io.NopCloser(strings.NewReader("payload")), shortDownloadWriter{}, 0, 7, nil, 0)
+	if !errors.Is(err, io.ErrShortWrite) || retry || written != 6 {
+		t.Fatalf("got %d %t %v", written, retry, err)
+	}
+}
+
+func TestDownloadDoesNotWritePastAnnouncedSize(t *testing.T) {
+	configureSetupCancellation(false)
+	var dst strings.Builder
+	written, retry, err := copyDownloadBody(io.NopCloser(strings.NewReader("too many bytes")), &dst, 4, 7, nil, 0)
+	if err == nil || retry || written != 0 || dst.Len() != 0 {
+		t.Fatalf("got %d %t %v with %q written", written, retry, err, dst.String())
+	}
+}
+
+func TestDownloadCacheRecoveryHonorsCancellation(t *testing.T) {
+	configureSetupCancellation(false)
+	t.Cleanup(func() { configureSetupCancellation(false) })
+	payload := []byte("complete payload")
+	dest := filepath.Join(t.TempDir(), "payload")
+	if err := os.WriteFile(dest+".part", payload, 0600); err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) { return nil, errors.New("offline") })}
+	err := downloadVerifiedWithOptions(client, "https://example.invalid/payload", dest, testSHA256(payload), func(phase string, done, total int64) {
+		if phase == downloadPhaseVerify {
+			requestSetupCancel()
+		}
+	}, fastDownloadOptions())
+	if !errors.Is(err, errSetupCancelled) {
+		t.Fatalf("got %v", err)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatal("cancelled recovery published a file")
+	}
+	data, err := os.ReadFile(dest + ".part")
+	if err != nil || string(data) != string(payload) {
+		t.Fatalf("cached transfer lost: %q %v", data, err)
+	}
+}

--- a/app/setup.go
+++ b/app/setup.go
@@ -289,9 +289,8 @@ func ensureRuntime(cfg *config, release, sumsSHA256 string) (string, error) {
 	os.RemoveAll(tmp)
 	if err := unzipTree(zipPath, tmp, ui); err != nil {
 		os.RemoveAll(tmp)
-		if removeZip {
-			os.Remove(zipPath)
-		}
+		// Keep the verified archive after cancellation, low space, or a file
+		// lock. The next attempt rechecks its hash and can unpack it locally.
 		return "", fmt.Errorf("unpacking %s: %w", runtimeZip, err)
 	}
 	if err := writeRuntimeReceipt(tmp, release, sumsSHA256, archiveSHA); err != nil {


### PR DESCRIPTION
Setup can reuse a completed download after a server outage or an ignored resume request, with the checksum verified before use. Runtime extraction failures keep the verified archive for the next attempt.

Also detects short disk writes and responses that exceed the announced size. Go race tests, Windows cross-build, and vet pass.
