### PR TITLE
Preserve unrelated files when cancelling setup

### DIFF
--- a/app/download_test.go
+++ b/app/download_test.go
@@ -342,7 +342,7 @@ func TestDownloadVerifiedCancelsBlockedBodyAndCleansPartial(t *testing.T) {
 		}, nil
 	})}
 	root := t.TempDir()
-	dest := filepath.Join(root, "payload.bin")
+	dest := filepath.Join(root, runtimeZip)
 	result := make(chan error, 1)
 	go func() {
 		result <- downloadVerifiedWithOptions(client, "https://example.invalid/payload", dest,

--- a/app/fetch.go
+++ b/app/fetch.go
@@ -19,11 +19,6 @@ import (
 // GitHub release on first launch (with a progress window), verifies it against
 // the authenticated SHA256SUMS, and decompresses the rootfs.
 
-var (
-	downloadedGuestArtifacts = []string{"guest-manifest.json", "build-spec.json", "vmlinuz-linux", "initramfs-linux.img"}
-	installedGuestArtifacts  = []string{"build-spec.json", "vmlinuz-linux", "initramfs-linux.img", "rootfs.ext4"}
-)
-
 func ensureGuest(cfg *config, release, sumsSHA256 string) error {
 	ready, err := installReceiptMatches(cfg.guestDir, release, sumsSHA256, installedGuestArtifacts)
 	if err != nil {

--- a/app/setup.go
+++ b/app/setup.go
@@ -30,8 +30,6 @@ import (
 //     Existing installs (C:\WINQ-EMU, stock QEMU from the old bootstrap)
 //     still win, so nothing already set up changes behavior.
 
-const runtimeZip = "winq-emu-alpha10-portable.zip"
-
 const (
 	legacyRuntimeRelease  = "https://github.com/tsouth89/try-omarchy-windows/releases/download/v0.0.6-preview"
 	legacyRuntimeManifest = "83f4a9cda6ee621c1e3ed756282aed18ca4dc719524d269ea6bbb76ff102229a"

--- a/app/setup_artifacts.go
+++ b/app/setup_artifacts.go
@@ -1,0 +1,8 @@
+package main
+
+const runtimeZip = "winq-emu-alpha10-portable.zip"
+
+var (
+	downloadedGuestArtifacts = []string{"guest-manifest.json", "build-spec.json", "vmlinuz-linux", "initramfs-linux.img"}
+	installedGuestArtifacts  = []string{"build-spec.json", "vmlinuz-linux", "initramfs-linux.img", "rootfs.ext4"}
+)

--- a/app/setup_cancel.go
+++ b/app/setup_cancel.go
@@ -106,18 +106,51 @@ func cleanupCancelledSetup(dir, executable string, removeAll bool) error {
 	if removeAll {
 		return removeInstallExceptExecutable(dir, executable)
 	}
-	return filepath.WalkDir(dir, func(path string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			if os.IsNotExist(walkErr) {
-				return nil
+	// Restrict cleanup to the launcher's own staging files. A recursive *.part
+	// sweep also removes unrelated downloads and files in shared folders.
+	guestFiles := append([]string{}, downloadedGuestArtifacts...)
+	guestFiles = append(guestFiles, "rootfs.ext4", "rootfs.ext4.zst", installReceiptFilename)
+	groups := []struct {
+		folder string
+		files  []string
+	}{
+		{"", []string{runtimeZip, dataLocationPointerName}},
+		{"guest", guestFiles},
+		{"guest.next", guestFiles},
+		{"vm", []string{"disk.raw", "disk.qcow2", "disk.qcow2" + portableBackingStateSuffix}},
+	}
+	for _, group := range groups {
+		folder := filepath.Join(dir, group.folder)
+		if group.folder != "" {
+			info, err := os.Lstat(folder)
+			if os.IsNotExist(err) {
+				continue
 			}
-			return walkErr
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
 		}
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".part") {
-			return nil
+		for _, name := range group.files {
+			path := filepath.Join(folder, name+".part")
+			info, err := os.Lstat(path)
+			if os.IsNotExist(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if !info.Mode().IsRegular() {
+				continue
+			}
+			if err := os.Remove(path); err != nil {
+				return err
+			}
 		}
-		return os.Remove(path)
-	})
+	}
+	return nil
 }
 
 func removeInstallExceptExecutable(dir, executable string) error {

--- a/app/setup_cancel_test.go
+++ b/app/setup_cancel_test.go
@@ -133,3 +133,57 @@ func TestCompleteInstallDetection(t *testing.T) {
 		t.Fatal("complete portable installation was not detected")
 	}
 }
+
+func TestCancelPreservesUnrelatedPartialFiles(t *testing.T) {
+	root := t.TempDir()
+	paths := []string{"notes.part", "guest/personal.part", "vm/project.part", "Shared/movie.part", "vm/before-reset-example/disk.qcow2.part"}
+	for _, name := range paths {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("keep me"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{runtimeZip + ".part", "guest/rootfs.ext4.zst.part", "guest.next/vmlinuz-linux.part", "vm/disk.qcow2.part"} {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("staging"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := cleanupCancelledSetup(root, "", false); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range paths {
+		data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
+		if err != nil || string(data) != "keep me" {
+			t.Fatalf("unrelated file %s changed: %q %v", name, data, err)
+		}
+	}
+	for _, name := range []string{runtimeZip + ".part", "guest/rootfs.ext4.zst.part", "guest.next/vmlinuz-linux.part", "vm/disk.qcow2.part"} {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(name))); !os.IsNotExist(err) {
+			t.Fatalf("staging file %s remains: %v", name, err)
+		}
+	}
+}
+
+func TestCancelDoesNotFollowGuestFolderLink(t *testing.T) {
+	root, external := t.TempDir(), t.TempDir()
+	path := filepath.Join(external, "rootfs.ext4.part")
+	if err := os.WriteFile(path, []byte("external file"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(root, "guest")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := cleanupCancelledSetup(root, "", false); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(path); err != nil || string(data) != "external file" {
+		t.Fatalf("external file changed: %q %v", data, err)
+	}
+}


### PR DESCRIPTION
Cancelling setup on an existing installation now removes only known launcher staging files. Unrelated `.part` files, shared folders, and retained recovery data are left alone.

Go race tests, Windows cross-build, and vet pass. Tests cover both staging cleanup and preservation of unrelated files.
