### PR TITLE
Expect guest compat revision 5 in the release smoke test

### DIFF
--- a/scripts/release/smoke-guest.py
+++ b/scripts/release/smoke-guest.py
@@ -27,7 +27,7 @@ FACT_CHECKS = {
     "sshd": "systemctl is-active sshd 2>/dev/null || true",
     "omarchy-repo-signed": "grep -A2 '^\\[omarchy\\]' /etc/pacman.conf | grep -q TrustAll && echo no || echo yes",
     "input-group": "id -nG | tr ' ' '\\n' | grep -qx input && echo yes || echo no",
-    "compat-version": "test \"$(cat /usr/share/try-omarchy/compat-version)\" = \"3:$(uname -r)\" && echo yes || echo no",
+    "compat-version": "test \"$(cat /usr/share/try-omarchy/compat-version)\" = \"5:$(uname -r)\" && echo yes || echo no",
     "kernel-modules": "test -f /usr/lib/modules/$(uname -r)/modules.dep.bin && echo yes || echo no",
     "ready-service": "systemctl is-enabled try-omarchy-ready.service 2>/dev/null || true",
 }


### PR DESCRIPTION
The v0.0.12-preview prepare run (33943314097) built the guest and booted the instant account, but the smoke test failed on the image facts because it still expects compat revision 3. Guest patches 0030 and 0031 raised the revision to 4 and then 5 for the clipboard bridge changes, so the check now expects 5.

No guest or launcher changes. Smoke-guest unit tests pass.