### PR TITLE
Remember when GPU rendering cannot run and keep runtime updates on CPU-only PCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ wins for that launch:
   "shareDisabled": false,
   "sharedFolderPrompted": true,
   "forwards": ["tcp:2222:22"],
-  "sshKey": ""
+  "sshKey": "",
+  "render": "auto"
 }
 ```
 
@@ -134,8 +135,15 @@ automatic guest RAM sizing (`-memory`, 0 keeps it automatic), `share` remembers
 the Windows folder shared into Omarchy (`-share`), `shareDisabled` turns that
 folder off without forgetting it, and `forwards` are loopback port
 forwards (`-forward`), and `sshKey` is the public key file to authorize when a
-forward targets sshd (`-ssh-key`). Open Settings from the tray, the Start menu,
-or `TryOmarchy.exe -settings`. Changes apply on the next launch.
+forward targets sshd (`-ssh-key`), and `render` picks the rendering path
+(`-render`). Open Settings from the tray, the Start menu, or
+`TryOmarchy.exe -settings`. Changes apply on the next launch.
+
+`render` is `auto` by default: the launcher tries GPU rendering and, when this
+PC cannot run it, remembers that in `render-probe.json` so later launches go
+straight to CPU rendering instead of repeating the failed attempts. It retries
+the GPU path when the runtime or the display drivers change, and once a week.
+`gpu` retries every launch; `cpu` never tries it (`-nogpu` means the same).
 
 ### Disk capacity
 

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -24,6 +24,7 @@ var diagnosticFiles = []string{
 	"runtime/" + runtimeReceiptFilename,
 	updateStateFilename,
 	payloadUpdateStateFilename,
+	renderProbeFilename,
 	"vm/shell.log",
 	"vm/qemu-stderr.log",
 	"vm/qemu.log",
@@ -237,6 +238,10 @@ func launcherFacts(cfg *config) map[string]string {
 		"launcher.version":  currentVersion,
 		"launcher.portable": fmt.Sprint(cfg.portable),
 		"launcher.noGpu":    fmt.Sprint(cfg.noGpu),
+		"launcher.render":   cfg.renderMode,
+		"launcher.useGpu":   fmt.Sprint(cfg.useGpu),
+		"runtime.id":        cfg.runtimeID,
+		"display.drivers":   cfg.displayDriver,
 		"time":              time.Now().Format(time.RFC3339),
 	}
 	for k, v := range hostFacts() {

--- a/app/main.go
+++ b/app/main.go
@@ -50,6 +50,10 @@ type config struct {
 	memOverrideMiB int
 	diskGiB        int
 	irqchipOff     bool
+	// Rendering decision inputs, see render_probe.go.
+	renderMode    string
+	runtimeID     string
+	displayDriver string
 }
 
 // pickGuestMem sizes the guest to the machine instead of demanding a fixed
@@ -136,7 +140,8 @@ func main() {
 	flag.BoolVar(&cfg.fullscreen, "fullscreen", false, "start fullscreen (Immersive)")
 	flag.IntVar(&cfg.memOverrideMiB, "memory", 0, "guest RAM in MiB (default: sized to this PC)")
 	flag.IntVar(&cfg.diskGiB, "disk-size", 0, "guest disk capacity in GiB (0: default; grows existing standard disks, never shrinks)")
-	flag.BoolVar(&cfg.noGpu, "nogpu", false, "force CPU rendering even if WINQ-EMU is installed")
+	flag.BoolVar(&cfg.noGpu, "nogpu", false, "force CPU rendering even if WINQ-EMU is installed (same as -render cpu)")
+	renderFlag := flag.String("render", "", "rendering path: auto (default), gpu, or cpu")
 	flag.BoolVar(&cfg.hostCursor, "host-cursor", false, "force the legacy Windows cursor over the guest")
 	flag.BoolVar(&cfg.instant, "instant", false, "skip first-boot questions and use the trial account")
 	flag.BoolVar(&cfg.portable, "portable", false, "run entirely from data and payload folders beside the executable")
@@ -327,6 +332,17 @@ func main() {
 	if err := applySettings(cfg, userSettings, explicitFlags, &forwards, sshKeyPath); err != nil {
 		fatal("Try Omarchy cannot use its settings: %v", err)
 	}
+	if explicitFlags["render"] {
+		mode, err := parseRenderMode(*renderFlag)
+		if err != nil {
+			fatal("%v", err)
+		}
+		cfg.renderMode = mode
+	}
+	if cfg.noGpu {
+		cfg.renderMode = renderCPU
+	}
+	cfg.noGpu = cfg.renderMode == renderCPU
 	if cfg.memOverrideMiB != 0 && (cfg.memOverrideMiB < minimumGuestMemoryMiB || cfg.memOverrideMiB > maximumGuestMemoryMiB) {
 		fatal("-memory must be between %d and %d MiB.", minimumGuestMemoryMiB, maximumGuestMemoryMiB)
 	}
@@ -502,8 +518,18 @@ func main() {
 	}
 	if gpuRoot != "" {
 		cfg.qemu = filepath.Join(gpuRoot, "bin", qemuExe)
-		cfg.useGpu = !cfg.noGpu
 		cfg.supportsSharing = true
+		cfg.runtimeID = runtimeIdentity(gpuRoot)
+		cfg.displayDriver = displayDriverIdentity()
+		probe, err := loadRenderProbe(cfg.dir)
+		if err != nil {
+			logf("ignoring %s: %v", renderProbeFilename, err)
+		}
+		var reason string
+		cfg.useGpu, reason = startWithGPU(cfg.renderMode, probe, cfg.runtimeID, cfg.displayDriver, time.Now())
+		if reason != "" {
+			logf("rendering: %s", reason)
+		}
 	} else {
 		cfg.qemu = stockQemu
 	}
@@ -700,10 +726,21 @@ func supervise(cfg *config, cmdline string) bool {
 				// Broken host GL (remote sessions, ancient drivers) kills the
 				// gl=on display the same way; same binary, CPU args, still up.
 				if cfg.useGpu {
+					if probe, _ := loadRenderProbe(cfg.dir); keepUpdatedRuntimeOnCPU(probe) {
+						// GPU mode never ran here, so the failure is the
+						// machine's graphics stack, not the new runtime: keep
+						// the update and let the CPU boot commit it.
+						logf("QEMU exited at startup - GPU rendering also failed before the runtime update, keeping the updated runtime and falling back to CPU rendering")
+						cfg.useGpu = false
+						break probe
+					}
 					if rolledBack, rollbackErr := rollbackPendingRuntimeUpdate(cfg.dir); rollbackErr != nil {
 						logf("runtime update rollback failed: %v", rollbackErr)
 					} else if rolledBack {
 						logf("updated runtime failed to start - restored previous runtime")
+						// The probe record must describe the runtime that
+						// actually boots, which is the restored one now.
+						cfg.runtimeID = runtimeIdentity(filepath.Dir(filepath.Dir(cfg.qemu)))
 						break probe
 					}
 					logf("QEMU exited at startup - falling back to CPU rendering")
@@ -754,6 +791,7 @@ func watch(cfg *config, qmp *qmpConn, exited <-chan error) bool {
 		if guestReady.Swap(false) {
 			commitLauncherUpdate(cfg.dir)
 			commitPayloadUpdates(cfg.dir)
+			recordRenderResult(cfg)
 		}
 		select {
 		case <-exited:
@@ -880,5 +918,24 @@ func waitExit(exited <-chan error, grace time.Duration, cfg *config) bool {
 		}
 		<-exited
 		return true
+	}
+}
+
+// recordRenderResult remembers which rendering path reached userspace with
+// the current runtime and drivers, so the next launch can skip attempts that
+// this machine cannot pass. A CPU result written while GPU was never tried
+// (settings say CPU) must not later be mistaken for a probe failure, so only
+// automatic and forced-GPU launches record CPU.
+func recordRenderResult(cfg *config) {
+	if cfg.runtimeID == "" || (cfg.renderMode == renderCPU && !cfg.useGpu) {
+		return
+	}
+	result := renderCPU
+	if cfg.useGpu {
+		result = renderGPU
+	}
+	probe := renderProbe{Result: result, RuntimeID: cfg.runtimeID, DisplayDriver: cfg.displayDriver, RecordedAt: time.Now()}
+	if err := saveRenderProbe(cfg.dir, probe); err != nil {
+		logf("could not record the rendering result: %v", err)
 	}
 }

--- a/app/qemu_nonwindows_test.go
+++ b/app/qemu_nonwindows_test.go
@@ -33,6 +33,10 @@ type config struct {
 	memOverrideMiB int
 	diskGiB        int
 	irqchipOff     bool
+	// Rendering decision inputs, see render_probe.go.
+	renderMode    string
+	runtimeID     string
+	displayDriver string
 }
 
 type progressUI struct{}
@@ -42,6 +46,7 @@ func (*progressUI) setStatus(string, ...any)         {}
 func (*progressUI) setProgress(current, total int64) {}
 func logf(string, ...any)                            {}
 func setSparse(*os.File) error                       { return nil }
+func displayDriverIdentity() string                  { return "" }
 func sparseCopy(dst, src *os.File, total int64, ui *progressUI) error {
 	_, err := io.Copy(dst, src)
 	return err

--- a/app/render_probe.go
+++ b/app/render_probe.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Rendering modes chosen by the user through settings.json or -render.
+const (
+	renderAuto = "auto"
+	renderGPU  = "gpu"
+	renderCPU  = "cpu"
+)
+
+// renderProbeFilename remembers how the last launch ended up rendering, so a
+// machine whose graphics driver cannot run the GPU path stops paying for two
+// failed GPU attempts and a runtime rollback on every launch.
+const renderProbeFilename = "render-probe.json"
+
+// renderProbeRetryAfter bounds how long a remembered CPU result is trusted.
+// Drivers and remote sessions change without touching the two identities
+// below, so the GPU path gets a fresh chance periodically.
+const renderProbeRetryAfter = 7 * 24 * time.Hour
+
+type renderProbe struct {
+	Schema int `json:"schema"`
+	// Result is renderGPU or renderCPU: how the guest last reached userspace.
+	Result string `json:"result"`
+	// RuntimeID identifies the QEMU runtime the result was observed with.
+	RuntimeID string `json:"runtimeID"`
+	// DisplayDriver identifies the Windows display drivers at the time.
+	DisplayDriver string    `json:"displayDriver"`
+	RecordedAt    time.Time `json:"recordedAt"`
+}
+
+func loadRenderProbe(dir string) (*renderProbe, error) {
+	data, err := os.ReadFile(filepath.Join(dir, renderProbeFilename))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxSettingsBytes {
+		return nil, fmt.Errorf("%s is too large", renderProbeFilename)
+	}
+	var p renderProbe
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	if p.Schema != 1 || (p.Result != renderGPU && p.Result != renderCPU) {
+		return nil, fmt.Errorf("%s is not a supported render probe record", renderProbeFilename)
+	}
+	return &p, nil
+}
+
+func saveRenderProbe(dir string, p renderProbe) error {
+	p.Schema = 1
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, renderProbeFilename)
+	tmp := path + ".part"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// current reports whether the record describes this runtime and driver set
+// and is recent enough to act on.
+func (p *renderProbe) current(runtimeID, displayDriver string, now time.Time) bool {
+	if p == nil || p.RuntimeID == "" || p.RuntimeID != runtimeID || p.DisplayDriver != displayDriver {
+		return false
+	}
+	return !p.RecordedAt.IsZero() && now.Sub(p.RecordedAt) < renderProbeRetryAfter && !p.RecordedAt.After(now.Add(time.Hour))
+}
+
+// startWithGPU decides the first launch attempt's rendering path. GPU stays
+// the default; only a remembered CPU result for the same runtime and driver
+// set skips it, and an explicit -render gpu always retries.
+func startWithGPU(mode string, probe *renderProbe, runtimeID, displayDriver string, now time.Time) (bool, string) {
+	switch mode {
+	case renderCPU:
+		return false, "CPU rendering chosen in settings"
+	case renderGPU:
+		return true, "GPU rendering chosen in settings"
+	}
+	if probe != nil && probe.Result == renderCPU && probe.current(runtimeID, displayDriver, now) {
+		return false, fmt.Sprintf("GPU rendering failed with this runtime and driver on %s; using CPU rendering (choose GPU in Settings to retry now)",
+			probe.RecordedAt.Local().Format("2006-01-02"))
+	}
+	return true, ""
+}
+
+// keepUpdatedRuntimeOnCPU decides what a GPU startup failure means while a
+// runtime update is still pending. A machine that already reached the desktop
+// on CPU rendering with the previous runtime has a graphics stack that never
+// ran GPU mode, so the failure says nothing about the new runtime: keep it and
+// fall back to CPU. Any other history rolls the runtime back, since a working
+// GPU path may have been broken by the update.
+func keepUpdatedRuntimeOnCPU(probe *renderProbe) bool {
+	return probe != nil && probe.Result == renderCPU
+}
+
+func parseRenderMode(value string) (string, error) {
+	switch v := strings.ToLower(strings.TrimSpace(value)); v {
+	case "", renderAuto:
+		return renderAuto, nil
+	case renderGPU, renderCPU:
+		return v, nil
+	}
+	return "", fmt.Errorf("render must be auto, gpu, or cpu")
+}
+
+// runtimeIdentity names the QEMU runtime for the probe record: the recorded
+// executable hash for a bundled runtime, or the executable's size and
+// modification time for a user-managed install without a receipt.
+func runtimeIdentity(gpuRoot string) string {
+	if data, err := os.ReadFile(filepath.Join(gpuRoot, runtimeReceiptFilename)); err == nil && len(data) <= maxInstallReceiptBytes {
+		var receipt runtimeReceipt
+		if json.Unmarshal(data, &receipt) == nil && validSHA256(receipt.Executable.SHA256) {
+			return "sha256:" + receipt.Executable.SHA256
+		}
+	}
+	info, err := os.Stat(filepath.Join(gpuRoot, "bin", "qemu-system-x86_64w.exe"))
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("stat:%d:%d", info.Size(), info.ModTime().UnixNano())
+}

--- a/app/render_probe_test.go
+++ b/app/render_probe_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderProbeRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if p, err := loadRenderProbe(dir); err != nil || p != nil {
+		t.Fatalf("missing probe should be nil, got %v %v", p, err)
+	}
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	want := renderProbe{Result: renderCPU, RuntimeID: "sha256:abc", DisplayDriver: "Intel=31.0.1", RecordedAt: now}
+	if err := saveRenderProbe(dir, want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadRenderProbe(dir)
+	if err != nil || got == nil || got.Schema != 1 || got.Result != renderCPU || got.RuntimeID != want.RuntimeID || !got.RecordedAt.Equal(now) {
+		t.Fatalf("round trip mismatch: %+v %v", got, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, renderProbeFilename), []byte(`{"schema":1,"result":"maybe"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadRenderProbe(dir); err == nil {
+		t.Fatal("unknown result must be rejected")
+	}
+}
+
+func TestStartWithGPUSkipsOnlyAMatchingRecentCPUResult(t *testing.T) {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	cpu := &renderProbe{Result: renderCPU, RuntimeID: "rt1", DisplayDriver: "drv1", RecordedAt: now.Add(-time.Hour)}
+	cases := []struct {
+		name          string
+		mode          string
+		probe         *renderProbe
+		runtime, drv  string
+		wantGPU       bool
+		reasonContain string
+	}{
+		{"no history", renderAuto, nil, "rt1", "drv1", true, ""},
+		{"matching cpu result", renderAuto, cpu, "rt1", "drv1", false, "using CPU rendering"},
+		{"runtime changed", renderAuto, cpu, "rt2", "drv1", true, ""},
+		{"driver changed", renderAuto, cpu, "rt1", "drv2", true, ""},
+		{"gpu result", renderAuto, &renderProbe{Result: renderGPU, RuntimeID: "rt1", DisplayDriver: "drv1", RecordedAt: now}, "rt1", "drv1", true, ""},
+		{"stale cpu result", renderAuto, &renderProbe{Result: renderCPU, RuntimeID: "rt1", DisplayDriver: "drv1", RecordedAt: now.Add(-8 * 24 * time.Hour)}, "rt1", "drv1", true, ""},
+		{"future timestamp", renderAuto, &renderProbe{Result: renderCPU, RuntimeID: "rt1", DisplayDriver: "drv1", RecordedAt: now.Add(48 * time.Hour)}, "rt1", "drv1", true, ""},
+		{"empty runtime id never matches", renderAuto, &renderProbe{Result: renderCPU, RecordedAt: now}, "", "", true, ""},
+		{"forced gpu", renderGPU, cpu, "rt1", "drv1", true, "GPU rendering chosen"},
+		{"forced cpu", renderCPU, nil, "rt1", "drv1", false, "CPU rendering chosen"},
+	}
+	for _, c := range cases {
+		gpu, reason := startWithGPU(c.mode, c.probe, c.runtime, c.drv, now)
+		if gpu != c.wantGPU || !strings.Contains(reason, c.reasonContain) {
+			t.Errorf("%s: got gpu=%v reason=%q, want gpu=%v containing %q", c.name, gpu, reason, c.wantGPU, c.reasonContain)
+		}
+	}
+}
+
+func TestKeepUpdatedRuntimeOnlyAfterACPUResult(t *testing.T) {
+	if keepUpdatedRuntimeOnCPU(nil) {
+		t.Fatal("no history must roll the runtime back")
+	}
+	if keepUpdatedRuntimeOnCPU(&renderProbe{Result: renderGPU}) {
+		t.Fatal("a working GPU path must roll the runtime back")
+	}
+	if !keepUpdatedRuntimeOnCPU(&renderProbe{Result: renderCPU, RuntimeID: "old"}) {
+		t.Fatal("a CPU-only machine must keep the updated runtime")
+	}
+}
+
+func TestParseRenderMode(t *testing.T) {
+	for input, want := range map[string]string{"": renderAuto, " Auto ": renderAuto, "GPU": renderGPU, "cpu": renderCPU} {
+		if got, err := parseRenderMode(input); err != nil || got != want {
+			t.Errorf("%q: got %q %v, want %q", input, got, err, want)
+		}
+	}
+	if _, err := parseRenderMode("software"); err == nil {
+		t.Fatal("unknown mode must be rejected")
+	}
+}
+
+func TestRuntimeIdentityPrefersTheReceiptHash(t *testing.T) {
+	root := t.TempDir()
+	if runtimeIdentity(root) != "" {
+		t.Fatal("missing runtime must have no identity")
+	}
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "qemu-system-x86_64w.exe"), []byte("qemu"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if id := runtimeIdentity(root); !strings.HasPrefix(id, "stat:4:") {
+		t.Fatalf("receipt-less runtime should use size and mtime, got %q", id)
+	}
+	sum := strings.Repeat("ab", 32)
+	receipt := `{"schema":1,"release":"r","manifestSHA256":"` + sum + `","archiveSHA256":"` + sum + `","executable":{"sha256":"` + sum + `","size":4,"modTimeUnixNano":1}}`
+	if err := os.WriteFile(filepath.Join(root, runtimeReceiptFilename), []byte(receipt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if id := runtimeIdentity(root); id != "sha256:"+sum {
+		t.Fatalf("receipt hash expected, got %q", id)
+	}
+}

--- a/app/render_probe_windows.go
+++ b/app/render_probe_windows.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"sort"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+// displayDriverIdentity summarizes the installed display drivers from the
+// display adapter class key, so a driver update invalidates a remembered CPU
+// rendering result. It never fails the launch: an unreadable registry yields
+// an empty identity, which the probe treats as unknown.
+func displayDriverIdentity() string {
+	const classKey = `SYSTEM\CurrentControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}`
+	var key syscall.Handle
+	path, _ := syscall.UTF16PtrFromString(classKey)
+	if syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE, path, 0, syscall.KEY_READ|syscall.KEY_ENUMERATE_SUB_KEYS, &key) != nil {
+		return ""
+	}
+	defer syscall.RegCloseKey(key)
+	var entries []string
+	for index := uint32(0); index < 64; index++ {
+		name := make([]uint16, 256)
+		nameLen := uint32(len(name))
+		if syscall.RegEnumKeyEx(key, index, &name[0], &nameLen, nil, nil, nil, nil) != nil {
+			break
+		}
+		var sub syscall.Handle
+		if syscall.RegOpenKeyEx(key, &name[0], 0, syscall.KEY_READ, &sub) != nil {
+			continue
+		}
+		desc := registryString(sub, "DriverDesc")
+		version := registryString(sub, "DriverVersion")
+		syscall.RegCloseKey(sub)
+		if desc == "" && version == "" {
+			continue
+		}
+		entries = append(entries, desc+"="+version)
+	}
+	sort.Strings(entries)
+	return strings.Join(entries, ";")
+}
+
+func registryString(key syscall.Handle, name string) string {
+	valueName, _ := syscall.UTF16PtrFromString(name)
+	var valueType, size uint32
+	if syscall.RegQueryValueEx(key, valueName, nil, &valueType, nil, &size) != nil || size == 0 || size > 4096 || valueType != syscall.REG_SZ {
+		return ""
+	}
+	buf := make([]uint16, size/2+1)
+	if syscall.RegQueryValueEx(key, valueName, nil, &valueType, (*byte)(unsafe.Pointer(&buf[0])), &size) != nil {
+		return ""
+	}
+	return strings.TrimSpace(syscall.UTF16ToString(buf))
+}

--- a/app/settings.go
+++ b/app/settings.go
@@ -37,6 +37,10 @@ type settings struct {
 	// Public key file authorized for the Omarchy account when a forward
 	// targets sshd. Empty picks the usual ~/.ssh/id_*.pub.
 	SSHKey string `json:"sshKey"`
+	// Render picks the rendering path: "auto" (or empty) tries the GPU path
+	// and remembers when this machine cannot run it, "gpu" retries it every
+	// launch, "cpu" never tries it.
+	Render string `json:"render,omitempty"`
 }
 
 const (
@@ -122,6 +126,9 @@ func (s settings) validate() error {
 	if s.MemoryMiB != 0 && (s.MemoryMiB < minimumGuestMemoryMiB || s.MemoryMiB > maximumGuestMemoryMiB) {
 		return fmt.Errorf("memoryMiB must be 0 (automatic) or between %d and %d", minimumGuestMemoryMiB, maximumGuestMemoryMiB)
 	}
+	if _, err := parseRenderMode(s.Render); err != nil {
+		return err
+	}
 	var l forwardList
 	for _, f := range s.Forwards {
 		if err := l.Set(f); err != nil {
@@ -134,14 +141,23 @@ func (s settings) validate() error {
 // settingsFromForm converts the Win32 controls into the persisted model. It
 // stays outside the window procedure so all input and file validation is
 // covered by the platform-independent test suite.
-func settingsFromForm(fullscreen, shareEnabled bool, memory, share, forwards, sshKey string) (settings, error) {
+func settingsFromForm(fullscreen, shareEnabled bool, memory, share, forwards, sshKey, render string) (settings, error) {
 	s := settings{
-		Fullscreen: fullscreen, Share: strings.TrimSpace(share),
+		Fullscreen: fullscreen, Share: strings.TrimSpace(share), Render: strings.TrimSpace(render),
 		ShareDisabled: !shareEnabled, SharedFolderPrompted: true,
 		SSHKey: strings.TrimSpace(sshKey),
 	}
 	if s.Share == "" {
 		s.ShareDisabled = false
+	}
+	mode, err := parseRenderMode(render)
+	if err != nil {
+		return s, err
+	}
+	if mode != renderAuto {
+		s.Render = mode
+	} else {
+		s.Render = ""
 	}
 	memory = strings.TrimSpace(memory)
 	if memory != "" {
@@ -199,6 +215,13 @@ func applySettings(cfg *config, s settings, explicit map[string]bool, forwards *
 	}
 	if !explicit["ssh-key"] {
 		*sshKeyPath = s.SSHKey
+	}
+	if !explicit["render"] {
+		mode, err := parseRenderMode(s.Render)
+		if err != nil {
+			return err
+		}
+		cfg.renderMode = mode
 	}
 	return nil
 }

--- a/app/settings_dialog_windows.go
+++ b/app/settings_dialog_windows.go
@@ -62,6 +62,11 @@ const (
 	settingsBackupID     = 2020
 	settingsRestoreID    = 2021
 	settingsResetID      = 2022
+	settingsRenderAutoID = 2023
+	settingsRenderGPUID  = 2024
+	settingsRenderCPUID  = 2025
+	bsAutoradiobutton    = 0x0009
+	wsGroup              = 0x00020000
 	settingsRecoveryDone = 0x8010
 )
 
@@ -90,6 +95,7 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 	className, _ := syscall.UTF16PtrFromString("TryOmarchySettings")
 	var hwnd uintptr
 	var hFull, hMem, hDisk, hShare, hShareOn, hFwd, hKey uintptr
+	var hRenderAuto, hRenderGPU, hRenderCPU uintptr
 
 	text := func(handle uintptr) string {
 		n, _, _ := procSendMessageW.Call(handle, wmGettextlength, 0, 0)
@@ -104,8 +110,14 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 	collect := func() (settings, error) {
 		checked, _, _ := procSendMessageW.Call(hFull, bmGetcheck, 0, 0)
 		shareChecked, _, _ := procSendMessageW.Call(hShareOn, bmGetcheck, 0, 0)
+		render := renderAuto
+		if r, _, _ := procSendMessageW.Call(hRenderGPU, bmGetcheck, 0, 0); r == bstChecked {
+			render = renderGPU
+		} else if r, _, _ := procSendMessageW.Call(hRenderCPU, bmGetcheck, 0, 0); r == bstChecked {
+			render = renderCPU
+		}
 		return settingsFromForm(checked == bstChecked, shareChecked == bstChecked,
-			text(hMem), text(hShare), text(hFwd), text(hKey))
+			text(hMem), text(hShare), text(hFwd), text(hKey), render)
 	}
 	browseFolder := func() {
 		if selected, ok := browseForFolder(hwnd, "Choose the Windows folder to share with Omarchy"); ok {
@@ -209,7 +221,7 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 		return false
 	}
 
-	const clientW, clientH = 480, 558
+	const clientW, clientH = 480, 616
 	rect := [4]int32{0, 0, clientW, clientH}
 	style := uintptr(wsCaption | wsSysmenu)
 	procAdjustWindowRectEx.Call(uintptr(unsafe.Pointer(&rect[0])), style, 0, 0)
@@ -240,7 +252,22 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 	if current.Fullscreen {
 		procSendMessageW.Call(hFull, bmSetcheck, bstChecked, 0)
 	}
-	y += 34
+	y += 30
+	mk("STATIC", "Rendering", left, y+3, labelW, 20, ssNoprefix, 0)
+	hRenderAuto = mk("BUTTON", "Automatic", fieldX, y, 90, 22, bsAutoradiobutton|wsGroup|wsTabstop, settingsRenderAutoID)
+	hRenderGPU = mk("BUTTON", "GPU", fieldX+96, y, 60, 22, bsAutoradiobutton, settingsRenderGPUID)
+	hRenderCPU = mk("BUTTON", "CPU", fieldX+162, y, 60, 22, bsAutoradiobutton, settingsRenderCPUID)
+	switch current.Render {
+	case renderGPU:
+		procSendMessageW.Call(hRenderGPU, bmSetcheck, bstChecked, 0)
+	case renderCPU:
+		procSendMessageW.Call(hRenderCPU, bmSetcheck, bstChecked, 0)
+	default:
+		procSendMessageW.Call(hRenderAuto, bmSetcheck, bstChecked, 0)
+	}
+	y += 24
+	mk("STATIC", "Automatic tries the GPU and remembers when this PC cannot use it. GPU retries every launch.", left, y, clientW-2*left, 20, ssNoprefix, 0)
+	y += 28
 	mk("STATIC", "Guest memory (MiB)", left, y+3, labelW, 20, ssNoprefix, 0)
 	hMem = mk("EDIT", strconv.Itoa(current.MemoryMiB), fieldX, y, 100, 24, wsBorder|wsTabstop|esAutohscroll, settingsMemID)
 	mk("STATIC", "0 = automatic", fieldX+112, y+3, fieldW-112, 20, ssNoprefix, 0)
@@ -284,10 +311,12 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 	y += 106
 	mk("STATIC", "SSH public key file\n(blank: your ~/.ssh/id_*.pub)", left, y+3, labelW, 40, ssNoprefix, 0)
 	hKey = mk("EDIT", current.SSHKey, fieldX, y, fieldW, 24, wsBorder|wsTabstop|esAutohscroll, settingsKeyID)
-	y += 36
+	// The two-line key label above is 40 px tall from y+3; start the next
+	// row below it or the label's second line paints over this text.
+	y += 50
 	mk("STATIC", "Changes apply the next time Omarchy starts.",
-		left, y, clientW-2*left, 36, ssNoprefix, 0)
-	y += 34
+		left, y, clientW-2*left, 20, ssNoprefix, 0)
+	y += 30
 	mk("STATIC", "Backup and recovery", left, y, clientW-2*left, 20, ssNoprefix, 0)
 	y += 24
 	for _, control := range []struct {

--- a/app/settings_test.go
+++ b/app/settings_test.go
@@ -106,12 +106,12 @@ func TestSettingsFromFormParsesAndValidatesEveryRow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := settingsFromForm(true, true, " 6144 ", ` C:\Users\me\Work `, " tcp:2222:22\r\n\r\n udp:5000:5000 ", " "+keyPath+" ")
+	s, err := settingsFromForm(true, true, " 6144 ", ` C:\Users\me\Work `, " tcp:2222:22\r\n\r\n udp:5000:5000 ", " "+keyPath+" ", " GPU ")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !s.Fullscreen || !s.SharedFolderPrompted || s.ShareDisabled || s.MemoryMiB != 6144 || s.Share != `C:\Users\me\Work` || s.SSHKey != keyPath ||
-		strings.Join(s.Forwards, ",") != "tcp:2222:22,udp:5000:5000" {
+		strings.Join(s.Forwards, ",") != "tcp:2222:22,udp:5000:5000" || s.Render != renderGPU {
 		t.Fatalf("form parsed incorrectly: %+v", s)
 	}
 
@@ -121,9 +121,15 @@ func TestSettingsFromFormParsesAndValidatesEveryRow(t *testing.T) {
 		"forward":      {"0", "tcp:22", ""},
 		"key":          {"0", "tcp:2222:22", filepath.Join(dir, "missing.pub")},
 	} {
-		if _, err := settingsFromForm(false, false, input[0], "", input[1], input[2]); err == nil {
+		if _, err := settingsFromForm(false, false, input[0], "", input[1], input[2], ""); err == nil {
 			t.Fatalf("%s input accepted", name)
 		}
+	}
+	if _, err := settingsFromForm(false, false, "0", "", "", "", "software"); err == nil {
+		t.Fatal("unknown render mode accepted")
+	}
+	if s, err := settingsFromForm(false, false, "0", "", "", "", " auto "); err != nil || s.Render != "" {
+		t.Fatalf("automatic rendering should be stored as the empty default, got %q %v", s.Render, err)
 	}
 }
 
@@ -155,7 +161,7 @@ func TestSharedFolderOfferAndEnableState(t *testing.T) {
 		t.Fatalf("disabled share = %q", got)
 	}
 
-	s, err := settingsFromForm(false, false, "0", `C:\Users\me\Work`, "", "")
+	s, err := settingsFromForm(false, false, "0", `C:\Users\me\Work`, "", "", "")
 	if err != nil || !s.ShareDisabled || s.activeShare() != "" || !s.SharedFolderPrompted {
 		t.Fatalf("disabled form state = %+v, %v", s, err)
 	}


### PR DESCRIPTION
Fixes two related problems found while testing v0.0.12-preview in a VM without GPU support.

Every launch on a PC whose graphics stack cannot start the GPU path paid for two failed GPU attempts before falling back. Worse, when a runtime update was pending, the GPU failure made the launcher roll the runtime back, so the next launch downloaded the 84 MB runtime again, and this repeated on every launch.

The launcher now records which rendering path reached userspace in `render-probe.json`, together with the runtime identity (the receipt's executable hash) and a summary of the installed display drivers. Later launches with the same runtime and drivers go straight to CPU rendering. The GPU path is retried when the runtime or drivers change, after a week, or when the user picks GPU in the new Rendering setting (auto, GPU, CPU, also `-render`; `-nogpu` still means CPU).

When a runtime update is pending and the GPU path fails, a PC that already reached the desktop on CPU rendering keeps the updated runtime and lets the CPU boot commit it. Any other history still rolls the runtime back, since a working GPU path may have been broken by the update.

Also fixes the Settings window text that the SSH key label painted over, and includes the probe file and the rendering decision in diagnostics.

Tested in the Win11 VM (nested WHPX, CPU only) across four launches on the real install: first launch with no record behaves as before and writes a CPU record; second launch downloads the runtime once, skips GPU, boots in 40 s and commits the update; third launch fetches only SHA256SUMS; a forced runtime update with a CPU record for an older runtime tries GPU once, keeps the new runtime, boots on CPU and commits. Settings screenshot checked at 100% scaling.