### PR TITLE
Size guest CPUs and RAM to the machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ wins for that launch:
   "schemaVersion": 1,
   "fullscreen": false,
   "memoryMiB": 0,
+  "cpus": 0,
   "share": "",
   "shareDisabled": false,
   "sharedFolderPrompted": true,
@@ -131,7 +132,8 @@ wins for that launch:
 ```
 
 `fullscreen` is the Immersive mode (`-fullscreen`), `memoryMiB` overrides the
-automatic guest RAM sizing (`-memory`, 0 keeps it automatic), `share` remembers
+automatic guest RAM sizing (`-memory`, 0 keeps it automatic), `cpus` overrides
+the automatic vCPU count (`-cpus`, 0 keeps it automatic), `share` remembers
 the Windows folder shared into Omarchy (`-share`), `shareDisabled` turns that
 folder off without forgetting it, and `forwards` are loopback port
 forwards (`-forward`), and `sshKey` is the public key file to authorize when a
@@ -144,6 +146,10 @@ PC cannot run it, remembers that in `render-probe.json` so later launches go
 straight to CPU rendering instead of repeating the failed attempts. It retries
 the GPU path when the runtime or the display drivers change, and once a week.
 `gpu` retries every launch; `cpu` never tries it (`-nogpu` means the same).
+
+Automatic sizing gives the guest all logical processors but two, between two
+and eight, and a third of the machine's RAM between 4 and 8 GiB (up to 12 GiB
+with GPU rendering), reduced to what Windows can spare at launch.
 
 ### Disk capacity
 

--- a/app/main.go
+++ b/app/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"runtime"
 	"bufio"
 	"bytes"
 	"encoding/json"
@@ -50,34 +51,20 @@ type config struct {
 	memOverrideMiB int
 	diskGiB        int
 	irqchipOff     bool
+	// Guest vCPUs chosen by the user (settings.json or -cpus); 0 = automatic.
+	cpuOverride  int
+	cpus         int
+	hostTotalMiB int
 	// Rendering decision inputs, see render_probe.go.
 	renderMode    string
 	runtimeID     string
 	displayDriver string
 }
 
-// pickGuestMem sizes the guest to the machine instead of demanding a fixed
-// 4-6 GB (which dies with "cannot set up guest memory" on a busy 8 GB PC):
-// the mode's ideal, minus a ~2 GB cushion for Windows, floored at 1 GB.
-// Omarchy runs lean (zram in the image), so a small guest beats no guest;
-// truly starved machines get the clean message from the memory ladder.
+// pickGuestMem sizes the guest RAM to this machine; see resources.go.
 func pickGuestMem(gpu bool) int {
-	want := 4096
-	if gpu {
-		want = 6144
-	}
-	_, avail := availMemMiB()
-	if avail == 0 {
-		return want
-	}
-	m := avail - 2048
-	if m > want {
-		m = want
-	}
-	if m < 1024 {
-		m = 1024
-	}
-	return m
+	total, avail := availMemMiB()
+	return pickGuestMemMiB(gpu, total, avail)
 }
 
 // memoryStarved reports whether the current attempt's QEMU died because the
@@ -139,6 +126,7 @@ func main() {
 	flag.BoolVar(&cfg.fresh, "fresh", false, "start over and retain the previous writable disk for recovery")
 	flag.BoolVar(&cfg.fullscreen, "fullscreen", false, "start fullscreen (Immersive)")
 	flag.IntVar(&cfg.memOverrideMiB, "memory", 0, "guest RAM in MiB (default: sized to this PC)")
+	flag.IntVar(&cfg.cpuOverride, "cpus", 0, "guest CPUs (default: sized to this PC)")
 	flag.IntVar(&cfg.diskGiB, "disk-size", 0, "guest disk capacity in GiB (0: default; grows existing standard disks, never shrinks)")
 	flag.BoolVar(&cfg.noGpu, "nogpu", false, "force CPU rendering even if WINQ-EMU is installed (same as -render cpu)")
 	renderFlag := flag.String("render", "", "rendering path: auto (default), gpu, or cpu")
@@ -604,6 +592,12 @@ func main() {
 		// if Windows cannot actually provide that much.
 		cfg.memMiB = cfg.memOverrideMiB
 	}
+	cfg.hostTotalMiB, _ = availMemMiB()
+	cfg.cpus = pickGuestCPUs(runtime.NumCPU())
+	if cfg.cpuOverride != 0 {
+		cfg.cpus = cfg.cpuOverride
+	}
+	logf("resources: %d of %d logical processors, %d MiB guest RAM", cfg.cpus, runtime.NumCPU(), cfg.memMiB)
 	getUI().setStatus("Starting Omarchy...")
 	stopTray := startTray(cfg)
 	defer stopTray()

--- a/app/qemu.go
+++ b/app/qemu.go
@@ -20,11 +20,10 @@ func buildQemuArgs(cfg *config, cmdline string) []string {
 	// Guest RAM is sized to the machine (pickGuestMem + the memory ladder);
 	// hostmem for GPU blob resources scales with it.
 	mem := fmt.Sprintf("%dM", cfg.memMiB)
-	hostmem := "4G"
-	if cfg.memMiB < 3072 {
-		hostmem = "1G"
-	} else if cfg.memMiB < 4096 {
-		hostmem = "2G"
+	hostmem := gpuHostMem(cfg.memMiB, cfg.hostTotalMiB)
+	smp := fmt.Sprint(cfg.cpus)
+	if cfg.cpus <= 0 {
+		smp = fmt.Sprint(minimumAutoGuestCPUs)
 	}
 	machine := "q35,accel=whpx"
 	if cfg.irqchipOff {
@@ -32,7 +31,7 @@ func buildQemuArgs(cfg *config, cmdline string) []string {
 	}
 	if cfg.useGpu {
 		args = append(args,
-			"-machine", machine, "-cpu", "host", "-smp", "6", "-m", mem,
+			"-machine", machine, "-cpu", "host", "-smp", smp, "-m", mem,
 			"-device", "virtio-vga-gl,blob=on,hostmem="+hostmem+",venus=on",
 			// The guest cursor is visible in the QEMU profile. Forcing SDL's host
 			// cursor as well produces two pointers that separate during motion.
@@ -46,7 +45,7 @@ func buildQemuArgs(cfg *config, cmdline string) []string {
 	} else {
 		args = append(args,
 			"-machine", machine, "-cpu", "qemu64,+ssse3,+sse4.1,+sse4.2,+popcnt,+aes",
-			"-smp", "6", "-m", mem,
+			"-smp", smp, "-m", mem,
 			"-vga", "none", "-device", "virtio-gpu-pci,id=gpu0",
 			"-display", sdlDisplay(false, cfg.hostCursor),
 			"-serial", "file:"+filepath.Join(vm, "serial.log"),

--- a/app/qemu_nonwindows_test.go
+++ b/app/qemu_nonwindows_test.go
@@ -33,6 +33,9 @@ type config struct {
 	memOverrideMiB int
 	diskGiB        int
 	irqchipOff     bool
+	cpuOverride    int
+	cpus           int
+	hostTotalMiB   int
 	// Rendering decision inputs, see render_probe.go.
 	renderMode    string
 	runtimeID     string
@@ -323,5 +326,18 @@ func TestBuildQemuArgsEscapesCommasInsidePaths(t *testing.T) {
 	}
 	if !strings.Contains(args, "local,path=/host/Work,,Notes,mount_tag=hostshare") {
 		t.Fatalf("share comma was not escaped: %s", args)
+	}
+}
+
+func TestBuildQemuArgsUsesTheChosenCPUCountAndHostMem(t *testing.T) {
+	cfg := &config{vmDir: "/vm", guestDir: "/guest", disk: "/vm/disk.raw", diskFormat: "raw",
+		memMiB: 8192, hostTotalMiB: 32768, cpus: 6, audio: "none", useGpu: true}
+	args := strings.Join(buildQemuArgs(cfg, "root=/dev/vda"), " ")
+	if !strings.Contains(args, " -smp 6 -m 8192M ") || !strings.Contains(args, "hostmem=8G") {
+		t.Fatalf("cpu count or hostmem missing: %s", args)
+	}
+	cfg.cpus = 0
+	if args = strings.Join(buildQemuArgs(cfg, "root=/dev/vda"), " "); !strings.Contains(args, " -smp 2 ") {
+		t.Fatalf("unset cpu count should fall back to the minimum: %s", args)
 	}
 }

--- a/app/resources.go
+++ b/app/resources.go
@@ -1,0 +1,93 @@
+package main
+
+// Guest sizing rules. They are pure so the platform-independent tests cover
+// them; main.go feeds them the live host numbers.
+
+const (
+	// A guest below two vCPUs makes Hyprland stutter on every input; above
+	// eight the scheduling overhead under WHPX outweighs what a desktop uses.
+	minimumAutoGuestCPUs = 2
+	maximumAutoGuestCPUs = 8
+	// Settings and -cpus accept an explicit count in this range.
+	minimumGuestCPUs = 1
+	maximumGuestCPUs = 64
+	// Automatic RAM: a third of the machine, clamped so a small laptop still
+	// gets a working guest and a workstation does not commit half its memory
+	// to a trial. GPU mode adds room for the guest side of blob resources.
+	minimumAutoGuestMemMiB = 4096
+	maximumAutoGuestMemMiB = 8192
+	gpuGuestMemExtraMiB    = 2048
+	maximumAutoGPUMemMiB   = 12288
+	// Windows keeps this much of what is available; the guest takes the rest.
+	hostMemReserveMiB = 2048
+	guestMemFloorMiB  = 1024
+)
+
+// pickGuestCPUs leaves two logical processors for Windows and the launcher,
+// gives small machines two vCPUs anyway (the host shares them), and caps the
+// count where more stops helping a desktop.
+func pickGuestCPUs(hostLogical int) int {
+	if hostLogical <= 0 {
+		return minimumAutoGuestCPUs
+	}
+	n := hostLogical - 2
+	if n < minimumAutoGuestCPUs {
+		n = minimumAutoGuestCPUs
+		if hostLogical < n {
+			n = hostLogical
+		}
+	}
+	if n > maximumAutoGuestCPUs {
+		n = maximumAutoGuestCPUs
+	}
+	return n
+}
+
+// pickGuestMemMiB sizes the guest to the machine instead of demanding a
+// fixed 4-6 GB (which dies with "cannot set up guest memory" on a busy 8 GB
+// PC). totalMiB and availMiB are the host's physical and available memory;
+// zero means the query failed and only the ideal applies.
+func pickGuestMemMiB(gpu bool, totalMiB, availMiB int) int {
+	want := minimumAutoGuestMemMiB
+	if totalMiB > 0 {
+		want = totalMiB / 3
+		if want < minimumAutoGuestMemMiB {
+			want = minimumAutoGuestMemMiB
+		}
+		if want > maximumAutoGuestMemMiB {
+			want = maximumAutoGuestMemMiB
+		}
+	}
+	if gpu {
+		want += gpuGuestMemExtraMiB
+		if want > maximumAutoGPUMemMiB {
+			want = maximumAutoGPUMemMiB
+		}
+	}
+	if availMiB == 0 {
+		return want
+	}
+	m := availMiB - hostMemReserveMiB
+	if m > want {
+		m = want
+	}
+	if m < guestMemFloorMiB {
+		m = guestMemFloorMiB
+	}
+	return m
+}
+
+// gpuHostMem sizes the host-side memory virtio-gpu can map for blob
+// resources. It scales with the guest and, on machines with plenty of RAM,
+// grows so large displays with many windows do not run out.
+func gpuHostMem(memMiB, hostTotalMiB int) string {
+	switch {
+	case memMiB < 3072:
+		return "1G"
+	case memMiB < 4096:
+		return "2G"
+	case memMiB >= 8192 && hostTotalMiB >= 32768:
+		return "8G"
+	}
+	return "4G"
+}

--- a/app/resources_test.go
+++ b/app/resources_test.go
@@ -1,0 +1,47 @@
+package main
+
+import "testing"
+
+func TestPickGuestCPUsLeavesTwoForWindowsWithinBounds(t *testing.T) {
+	for host, want := range map[int]int{0: 2, 1: 1, 2: 2, 4: 2, 6: 4, 8: 6, 10: 8, 12: 8, 32: 8} {
+		if got := pickGuestCPUs(host); got != want {
+			t.Errorf("host %d: got %d vCPUs, want %d", host, got, want)
+		}
+	}
+}
+
+func TestPickGuestMemScalesWithTheMachine(t *testing.T) {
+	cases := []struct {
+		name         string
+		gpu          bool
+		total, avail int
+		want         int
+	}{
+		{"unknown host", false, 0, 0, 4096},
+		{"unknown host gpu", true, 0, 0, 6144},
+		{"8 GB laptop busy", false, 8192, 5000, 2952},
+		{"8 GB laptop idle", false, 8192, 7000, 4096},
+		{"16 GB laptop", false, 16384, 12000, 5461},
+		{"16 GB laptop gpu", true, 16384, 12000, 7509},
+		{"32 GB desktop", false, 32768, 28000, 8192},
+		{"32 GB desktop gpu", true, 32768, 28000, 10240},
+		{"64 GB workstation gpu", true, 65536, 60000, 10240},
+		{"starved", false, 8192, 1500, 1024},
+	}
+	for _, c := range cases {
+		if got := pickGuestMemMiB(c.gpu, c.total, c.avail); got != c.want {
+			t.Errorf("%s: got %d MiB, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+func TestGPUHostMemFollowsGuestAndHost(t *testing.T) {
+	for _, c := range []struct {
+		mem, total int
+		want       string
+	}{{2048, 8192, "1G"}, {3072, 8192, "2G"}, {4096, 16384, "4G"}, {8192, 16384, "4G"}, {8192, 32768, "8G"}, {10240, 65536, "8G"}} {
+		if got := gpuHostMem(c.mem, c.total); got != c.want {
+			t.Errorf("mem %d total %d: got %s, want %s", c.mem, c.total, got, c.want)
+		}
+	}
+}

--- a/app/settings.go
+++ b/app/settings.go
@@ -24,6 +24,8 @@ type settings struct {
 	Fullscreen bool `json:"fullscreen"`
 	// Guest RAM in MiB. 0 sizes it to the machine automatically.
 	MemoryMiB int `json:"memoryMiB"`
+	// Guest CPUs. 0 sizes them to the machine automatically.
+	CPUs int `json:"cpus,omitempty"`
 	// Windows folder shared into Omarchy. Empty means no share.
 	Share string `json:"share"`
 	// ShareDisabled remembers a chosen folder while preventing it from being
@@ -126,6 +128,9 @@ func (s settings) validate() error {
 	if s.MemoryMiB != 0 && (s.MemoryMiB < minimumGuestMemoryMiB || s.MemoryMiB > maximumGuestMemoryMiB) {
 		return fmt.Errorf("memoryMiB must be 0 (automatic) or between %d and %d", minimumGuestMemoryMiB, maximumGuestMemoryMiB)
 	}
+	if s.CPUs != 0 && (s.CPUs < minimumGuestCPUs || s.CPUs > maximumGuestCPUs) {
+		return fmt.Errorf("cpus must be 0 (automatic) or between %d and %d", minimumGuestCPUs, maximumGuestCPUs)
+	}
 	if _, err := parseRenderMode(s.Render); err != nil {
 		return err
 	}
@@ -141,7 +146,7 @@ func (s settings) validate() error {
 // settingsFromForm converts the Win32 controls into the persisted model. It
 // stays outside the window procedure so all input and file validation is
 // covered by the platform-independent test suite.
-func settingsFromForm(fullscreen, shareEnabled bool, memory, share, forwards, sshKey, render string) (settings, error) {
+func settingsFromForm(fullscreen, shareEnabled bool, memory, cpus, share, forwards, sshKey, render string) (settings, error) {
 	s := settings{
 		Fullscreen: fullscreen, Share: strings.TrimSpace(share), Render: strings.TrimSpace(render),
 		ShareDisabled: !shareEnabled, SharedFolderPrompted: true,
@@ -166,6 +171,14 @@ func settingsFromForm(fullscreen, shareEnabled bool, memory, share, forwards, ss
 			return s, fmt.Errorf("guest memory must be a number of MiB, or 0 for automatic")
 		}
 		s.MemoryMiB = n
+	}
+	cpus = strings.TrimSpace(cpus)
+	if cpus != "" {
+		n, err := strconv.Atoi(cpus)
+		if err != nil {
+			return s, fmt.Errorf("guest CPUs must be a number, or 0 for automatic")
+		}
+		s.CPUs = n
 	}
 	for _, line := range strings.Split(strings.ReplaceAll(forwards, "\r\n", "\n"), "\n") {
 		if line = strings.TrimSpace(line); line != "" {
@@ -201,6 +214,9 @@ func applySettings(cfg *config, s settings, explicit map[string]bool, forwards *
 	}
 	if !explicit["memory"] {
 		cfg.memOverrideMiB = s.MemoryMiB
+	}
+	if !explicit["cpus"] {
+		cfg.cpuOverride = s.CPUs
 	}
 	if !explicit["share"] {
 		cfg.share = s.activeShare()

--- a/app/settings_dialog_windows.go
+++ b/app/settings_dialog_windows.go
@@ -65,6 +65,7 @@ const (
 	settingsRenderAutoID = 2023
 	settingsRenderGPUID  = 2024
 	settingsRenderCPUID  = 2025
+	settingsCPUsID       = 2026
 	bsAutoradiobutton    = 0x0009
 	wsGroup              = 0x00020000
 	settingsRecoveryDone = 0x8010
@@ -94,7 +95,7 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 	hInst, _, _ := procGetModuleHandleW.Call(0)
 	className, _ := syscall.UTF16PtrFromString("TryOmarchySettings")
 	var hwnd uintptr
-	var hFull, hMem, hDisk, hShare, hShareOn, hFwd, hKey uintptr
+	var hFull, hMem, hCPUs, hDisk, hShare, hShareOn, hFwd, hKey uintptr
 	var hRenderAuto, hRenderGPU, hRenderCPU uintptr
 
 	text := func(handle uintptr) string {
@@ -117,7 +118,7 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 			render = renderCPU
 		}
 		return settingsFromForm(checked == bstChecked, shareChecked == bstChecked,
-			text(hMem), text(hShare), text(hFwd), text(hKey), render)
+			text(hMem), text(hCPUs), text(hShare), text(hFwd), text(hKey), render)
 	}
 	browseFolder := func() {
 		if selected, ok := browseForFolder(hwnd, "Choose the Windows folder to share with Omarchy"); ok {
@@ -221,7 +222,7 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 		return false
 	}
 
-	const clientW, clientH = 480, 616
+	const clientW, clientH = 480, 650
 	rect := [4]int32{0, 0, clientW, clientH}
 	style := uintptr(wsCaption | wsSysmenu)
 	procAdjustWindowRectEx.Call(uintptr(unsafe.Pointer(&rect[0])), style, 0, 0)
@@ -271,6 +272,10 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 	mk("STATIC", "Guest memory (MiB)", left, y+3, labelW, 20, ssNoprefix, 0)
 	hMem = mk("EDIT", strconv.Itoa(current.MemoryMiB), fieldX, y, 100, 24, wsBorder|wsTabstop|esAutohscroll, settingsMemID)
 	mk("STATIC", "0 = automatic", fieldX+112, y+3, fieldW-112, 20, ssNoprefix, 0)
+	y += 34
+	mk("STATIC", "Guest CPUs", left, y+3, labelW, 20, ssNoprefix, 0)
+	hCPUs = mk("EDIT", strconv.Itoa(current.CPUs), fieldX, y, 100, 24, wsBorder|wsTabstop|esAutohscroll, settingsCPUsID)
+	mk("STATIC", fmt.Sprintf("0 = automatic (%d of %d)", pickGuestCPUs(runtime.NumCPU()), runtime.NumCPU()), fieldX+112, y+3, fieldW-112, 20, ssNoprefix, 0)
 	y += 34
 	mk("STATIC", "Disk capacity (GiB)", left, y+3, labelW, 20, ssNoprefix, 0)
 	hDisk = mk("EDIT", strconv.Itoa(storage.DiskGiB), fieldX, y, 100, 24, wsBorder|wsTabstop|esAutohscroll, settingsDiskID)

--- a/app/settings_test.go
+++ b/app/settings_test.go
@@ -106,12 +106,12 @@ func TestSettingsFromFormParsesAndValidatesEveryRow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := settingsFromForm(true, true, " 6144 ", ` C:\Users\me\Work `, " tcp:2222:22\r\n\r\n udp:5000:5000 ", " "+keyPath+" ", " GPU ")
+	s, err := settingsFromForm(true, true, " 6144 ", " 4 ", ` C:\Users\me\Work `, " tcp:2222:22\r\n\r\n udp:5000:5000 ", " "+keyPath+" ", " GPU ")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !s.Fullscreen || !s.SharedFolderPrompted || s.ShareDisabled || s.MemoryMiB != 6144 || s.Share != `C:\Users\me\Work` || s.SSHKey != keyPath ||
-		strings.Join(s.Forwards, ",") != "tcp:2222:22,udp:5000:5000" || s.Render != renderGPU {
+		strings.Join(s.Forwards, ",") != "tcp:2222:22,udp:5000:5000" || s.Render != renderGPU || s.CPUs != 4 {
 		t.Fatalf("form parsed incorrectly: %+v", s)
 	}
 
@@ -121,14 +121,19 @@ func TestSettingsFromFormParsesAndValidatesEveryRow(t *testing.T) {
 		"forward":      {"0", "tcp:22", ""},
 		"key":          {"0", "tcp:2222:22", filepath.Join(dir, "missing.pub")},
 	} {
-		if _, err := settingsFromForm(false, false, input[0], "", input[1], input[2], ""); err == nil {
+		if _, err := settingsFromForm(false, false, input[0], "", "", input[1], input[2], ""); err == nil {
 			t.Fatalf("%s input accepted", name)
 		}
 	}
-	if _, err := settingsFromForm(false, false, "0", "", "", "", "software"); err == nil {
+	for _, cpus := range []string{"many", "0x4", "65", "-1"} {
+		if _, err := settingsFromForm(false, false, "0", cpus, "", "", "", ""); err == nil {
+			t.Fatalf("cpus %q accepted", cpus)
+		}
+	}
+	if _, err := settingsFromForm(false, false, "0", "", "", "", "", "software"); err == nil {
 		t.Fatal("unknown render mode accepted")
 	}
-	if s, err := settingsFromForm(false, false, "0", "", "", "", " auto "); err != nil || s.Render != "" {
+	if s, err := settingsFromForm(false, false, "0", "", "", "", "", " auto "); err != nil || s.Render != "" {
 		t.Fatalf("automatic rendering should be stored as the empty default, got %q %v", s.Render, err)
 	}
 }
@@ -161,7 +166,7 @@ func TestSharedFolderOfferAndEnableState(t *testing.T) {
 		t.Fatalf("disabled share = %q", got)
 	}
 
-	s, err := settingsFromForm(false, false, "0", `C:\Users\me\Work`, "", "", "")
+	s, err := settingsFromForm(false, false, "0", "", `C:\Users\me\Work`, "", "", "")
 	if err != nil || !s.ShareDisabled || s.activeShare() != "" || !s.SharedFolderPrompted {
 		t.Fatalf("disabled form state = %+v, %v", s, err)
 	}


### PR DESCRIPTION
The guest always started with six vCPUs and at most 4 GiB (6 GiB on the GPU path) regardless of the host. A four-core laptop was oversubscribed and a 32 GB workstation was left idle.

Automatic sizing now gives the guest all logical processors but two, clamped between two and eight, and a third of the machine's RAM clamped between 4 and 8 GiB (up to 12 GiB with GPU rendering), still reduced to what Windows can spare at launch and still subject to the memory ladder. GPU blob host memory grows to 8 GiB on machines with 32 GiB or more RAM and an 8 GiB guest. The rules live in `resources.go` as pure functions with tests.

A Guest CPUs row in Settings (showing the automatic choice for this PC) and `-cpus` override the count; `cpus` in settings.json persists it. The launcher logs the chosen resources once per launch.

Tested in the 4-core, 8 GB Win11 VM: the guest started with `-smp 2 -m 3519M` per the rules and reached userspace ready 14 seconds after QEMU start, where the same VM took 40 to 70 seconds with six vCPUs on four cores. Settings screenshot checked.