### PR TITLE
Budget restores by compressed size, keep receipt times, log early lines

### DIFF
--- a/app/backup.go
+++ b/app/backup.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"time"
 	"archive/zip"
 	"crypto/sha256"
 	"encoding/hex"
@@ -291,7 +292,7 @@ func restoreVMBackupProgress(source, destination string, report backupProgress) 
 	for _, entry := range manifest.Files {
 		total += entry.Size
 	}
-	if err = requireDiskSpace(filepath.Dir(destination), total+diskSpaceReserve); err != nil {
+	if err = requireDiskSpace(filepath.Dir(destination), restoreSpaceEstimate(manifest, files)); err != nil {
 		return err
 	}
 	staging, err := os.MkdirTemp(filepath.Dir(destination), ".try-omarchy-restore-*")
@@ -309,11 +310,74 @@ func restoreVMBackupProgress(source, destination string, report backupProgress) 
 			return err
 		}
 	}
+	if err = restampReceiptTimes(staging); err != nil {
+		return err
+	}
 	// The main launcher uses Windows, where Rename cannot replace a directory.
 	if _, err = os.Lstat(destination); !os.IsNotExist(err) {
 		return fmt.Errorf("restore destination appeared during copying")
 	}
 	return os.Rename(staging, destination)
+}
+
+// restoreSpaceEstimate budgets a restore from the archive's compressed size
+// rather than the files' nominal size. The guest disk and rootfs are sparse:
+// their zero runs deflate to almost nothing and are restored as holes, while
+// the guest's already-compressed data stays close to its stored size. Budgeting
+// the nominal size instead refused a 10 GB backup on a drive with 30 GB free.
+// The margin covers text that deflates well; a drive that is still short fails
+// the copy with a disk-full error before anything is published.
+func restoreSpaceEstimate(manifest backupManifest, files map[string]*zip.File) int64 {
+	var compressed int64
+	for _, entry := range manifest.Files {
+		if f := files[entry.Name]; f != nil {
+			compressed += int64(f.CompressedSize64)
+		}
+	}
+	return compressed + compressed/4 + diskSpaceReserve
+}
+
+// restampReceiptTimes gives restored guest and runtime files the modification
+// times their install receipts recorded. The receipts compare those times on
+// every launch, so without this a restored copy re-downloaded its image and
+// runtime on first launch even though every byte had just been verified.
+func restampReceiptTimes(root string) error {
+	guest := filepath.Join(root, "guest")
+	if data, err := os.ReadFile(filepath.Join(guest, installReceiptFilename)); err == nil && len(data) <= maxInstallReceiptBytes {
+		var receipt installReceipt
+		if json.Unmarshal(data, &receipt) == nil {
+			for name, entry := range receipt.Files {
+				if err := restampFile(filepath.Join(guest, name), entry); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	runtime := filepath.Join(root, "runtime")
+	if data, err := os.ReadFile(filepath.Join(runtime, runtimeReceiptFilename)); err == nil && len(data) <= maxInstallReceiptBytes {
+		var receipt runtimeReceipt
+		if json.Unmarshal(data, &receipt) == nil {
+			if err := restampFile(filepath.Join(runtime, "bin", "qemu-system-x86_64w.exe"), receipt.Executable); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func restampFile(path string, entry verifiedArtifact) error {
+	if entry.ModTimeUnixNano == 0 || strings.Contains(filepath.ToSlash(filepath.Clean("/"+path)), "/../") {
+		return nil
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() != entry.Size {
+		return nil
+	}
+	when := time.Unix(0, entry.ModTimeUnixNano)
+	if err := os.Chtimes(path, when, when); err != nil {
+		return fmt.Errorf("restoring file time of %s: %w", filepath.Base(path), err)
+	}
+	return nil
 }
 
 func restoreBackupFile(z *zip.File, target string, entry backupEntry, processed *int64, total int64, report backupProgress) error {

--- a/app/backup_test.go
+++ b/app/backup_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -275,4 +276,53 @@ func TestBackupAndRestoreReportCompleteProgress(t *testing.T) {
 	check(func(report backupProgress) error {
 		return restoreVMBackupProgress(archive, filepath.Join(filepath.Dir(dir), "progress-restore"), report)
 	})
+}
+
+func TestVMRestoreBudgetsCompressedSizeAndRestampsReceipts(t *testing.T) {
+	dir, archive := backupFixture(t)
+	spec := filepath.Join(dir, "guest", "build-spec.json")
+	info, err := os.Stat(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stamp := int64(1700000000123456700)
+	sum := strings.Repeat("ab", 32)
+	receipt := `{"version":1,"release":"r","manifestSHA256":"` + sum + `","files":{"build-spec.json":{"sha256":"` + sum + `","size":` + strconv.FormatInt(info.Size(), 10) + `,"modTimeUnixNano":` + strconv.FormatInt(stamp, 10) + `}}}`
+	if err := os.WriteFile(filepath.Join(dir, "guest", installReceiptFilename), []byte(receipt), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeVMBackup(dir, archive); err != nil {
+		t.Fatal(err)
+	}
+	z, err := zip.OpenReader(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, files, err := readVMBackup(z)
+	z.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var nominal int64
+	for _, entry := range manifest.Files {
+		nominal += entry.Size
+	}
+	estimate := restoreSpaceEstimate(manifest, files)
+	if estimate >= nominal+diskSpaceReserve || estimate <= diskSpaceReserve {
+		t.Fatalf("estimate %d should sit between the reserve and the nominal %d", estimate, nominal)
+	}
+	previous := diskFreeBytes
+	t.Cleanup(func() { diskFreeBytes = previous })
+	diskFreeBytes = func(string) (int64, error) { return estimate, nil }
+	destination := filepath.Join(filepath.Dir(dir), "restored")
+	if err := restoreVMBackup(archive, destination); err != nil {
+		t.Fatalf("restore with compressed-size budget failed: %v", err)
+	}
+	restored, err := os.Stat(filepath.Join(destination, "guest", "build-spec.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restored.ModTime().UnixNano() != stamp {
+		t.Fatalf("receipt time not restored: got %d, want %d", restored.ModTime().UnixNano(), stamp)
+	}
 }

--- a/app/main.go
+++ b/app/main.go
@@ -85,9 +85,17 @@ type buildSpec struct {
 
 var logFile *os.File
 
+// earlyLog holds lines written before shell.log is opened (update recovery,
+// settings, the restored-payload decision) so they land at the top of the
+// session's log instead of vanishing.
+var earlyLog []string
+
 func logf(format string, a ...any) {
+	line := fmt.Sprintf("%s %s", time.Now().Format("15:04:05"), fmt.Sprintf(format, a...))
 	if logFile != nil {
-		fmt.Fprintf(logFile, "%s %s\n", time.Now().Format("15:04:05"), fmt.Sprintf(format, a...))
+		fmt.Fprintln(logFile, line)
+	} else if len(earlyLog) < 200 {
+		earlyLog = append(earlyLog, line)
 	}
 }
 
@@ -397,6 +405,10 @@ func main() {
 	}
 	logFile, _ = os.OpenFile(filepath.Join(cfg.vmDir, "shell.log"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if logFile != nil {
+		for _, line := range earlyLog {
+			fmt.Fprintln(logFile, line)
+		}
+		earlyLog = nil
 		// A windowsgui process has no console: an unhandled panic (any
 		// goroutine) writes its trace to stderr and vanishes. It happened - the
 		// shell died silently mid-session leaving QEMU orphaned. Route stderr

--- a/app/recovery_windows.go
+++ b/app/recovery_windows.go
@@ -73,6 +73,11 @@ func runRecoveryUI(dir, action string) error {
 		if err := createRestoredLaunchers(destination); err != nil {
 			infoBox("Your data was restored to:\n\n" + destination + "\n\nThe startup shortcuts could not be created: " + err.Error() + "\n\nYou can start this copy with -dir pointing to its folder.")
 		} else {
+			// The restored copy has its shortcuts; the first launch must not
+			// offer them again.
+			if err := recordShortcutOffer(destination); err != nil {
+				logf("could not record the shortcut offer for %s: %v", destination, err)
+			}
 			infoBox("Restored to:\n\n" + destination + "\n\nOpen Start Omarchy in that folder to use this copy, or Settings to review it first. Your original installation and shortcuts are unchanged.")
 		}
 	case "reset":


### PR DESCRIPTION
Three fixes from the v0.0.12 candidate testing.

Restore refused any drive without free space equal to the backup's nominal size: 33 GB for a 10 GB backup, because a 24 GiB sparse disk and a 6 GiB rootfs count in full. It now budgets from the archive's compressed size plus a quarter margin and the usual reserve. Zero runs deflate to almost nothing and are restored as holes, and the guest's already-compressed data stays near its stored size, so the compressed size tracks what the sparse restore will allocate. A drive that is still short fails the copy with the existing disk-full message before anything is published.

Restored guest and runtime files now get the modification times their receipts recorded. The receipts compare those times on every launch, so a restored copy used to re-download its image and runtime on first launch even though every byte had just been verified.

A restore started from Settings records the shortcut offer in the restored folder, since it creates the shortcuts itself; the copy's first launch no longer asks again. The command-line restore creates no shortcuts, so it still asks.

Lines logged before shell.log opens (update recovery, saved settings, the restored-payload decision) are buffered and written at the top of the session. The "using restored guest and runtime for this recovery launch" line was lost before this.

Tested in the Win11 VM: the launcher's own `-restore` of the 4.45 GB backup succeeded on a drive with 12.7 GB free and used 9.6 GB; all five receipt timestamps matched afterwards; launching the restored v0.0.11 copy against its own release downloaded nothing and reached ready in 43 s, with the recovery line and the early ssh line at the top of the log.