### PR TITLE
Add an uninstall path and an Apps & features entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,15 @@ The local trial account is named `omarchy` and its lock-screen password is `omar
 
 ### How do I remove Try Omarchy?
 
-Delete the data folder you chose during setup. That removes the launcher, runtime, image, and writable virtual disk. If you used an alternate location, also delete `%LOCALAPPDATA%\TryOmarchy\data-location.json`. If you created Windows shortcuts, remove them from the Start menu or Desktop like any other shortcut. The original downloaded `TryOmarchy.exe` can be deleted separately.
+Close Omarchy, then use **Remove Try Omarchy** in Settings, the Try Omarchy
+entry in Windows Apps & features, or `TryOmarchy.exe -uninstall`. It offers a
+full backup first, then removes the shortcuts, the Apps & features entry, the
+saved data location, and the data folder with the launcher, runtime, image,
+and writable virtual disk. Windows shared folders and the original downloaded
+`TryOmarchy.exe` are kept; delete those by hand if you no longer want them.
+
+Removing the data folder by hand still works; the Apps & features entry then
+stays until you remove it from there.
 
 ### I have the full Hyper-V feature set installed. Will it conflict?
 

--- a/app/backup.go
+++ b/app/backup.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"time"
 	"archive/zip"
 	"crypto/sha256"
 	"encoding/hex"
@@ -12,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const backupManifestName = "backup.json"

--- a/app/launcher_windows.go
+++ b/app/launcher_windows.go
@@ -187,6 +187,9 @@ func offerLauncherShortcuts(dir string) {
 	if err := ensureSettingsShortcutForExistingInstall(target, installDir); err != nil {
 		logf("settings shortcut: %v", err)
 	}
+	if err := registerUninstallEntry(target, installDir); err != nil {
+		logf("apps & features entry: %v", err)
+	}
 	if shortcutOfferRecorded(installDir) {
 		return
 	}

--- a/app/main.go
+++ b/app/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"runtime"
 	"bufio"
 	"bytes"
 	"encoding/json"
@@ -15,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -144,7 +144,9 @@ func main() {
 	var forwards forwardList
 	flag.Var(&forwards, "forward", "forward a Windows loopback port into Omarchy, as tcp:2222:22 or 8080:80 (repeatable)")
 	sshPort := flag.Int("ssh", 0, "forward this Windows loopback port to Omarchy's sshd and start sshd for the session")
-	recoveryAction := flag.String("recovery", "", "open backup, restore, or reset controls for a stopped standard install")
+	recoveryAction := flag.String("recovery", "", "open backup, restore, reset, or uninstall controls for a stopped standard install")
+	uninstall := flag.Bool("uninstall", false, "remove this Try Omarchy installation: shortcuts, the Apps & features entry, and the data folder")
+	uninstallFinish := flag.Bool("uninstall-finish", false, "internal: delete the data folder after the launcher inside it exits")
 	backupPath := flag.String("backup", "", "back up a stopped standard VM to a new ZIP file, then exit")
 	restorePath := flag.String("restore", "", "restore a trusted backup into a new folder selected with -dir, then exit")
 	openSettings := flag.Bool("settings", false, "open the settings window, then exit")
@@ -166,8 +168,14 @@ func main() {
 	updateWaitPID := flag.Int("update-wait-pid", 0, "internal: process to wait for before replacing the launcher")
 	updateRestartArgs := flag.String("update-restart-args", "", "internal: encoded launcher restart arguments")
 	flag.Parse()
+	if *uninstall {
+		if *recoveryAction != "" && *recoveryAction != "uninstall" {
+			fatal("Choose one recovery action: backup, restore, reset, or uninstall.")
+		}
+		*recoveryAction = "uninstall"
+	}
 	maintenance := *backupPath != "" || *restorePath != "" || *recoveryAction != ""
-	if *recoveryAction != "" && (*recoveryAction != "backup" && *recoveryAction != "restore" && *recoveryAction != "reset" || *backupPath != "" || *restorePath != "") {
+	if *recoveryAction != "" && (*recoveryAction != "backup" && *recoveryAction != "restore" && *recoveryAction != "reset" && *recoveryAction != "uninstall" || *backupPath != "" || *restorePath != "") {
 		fatal("Choose one recovery action: backup, restore, or reset.")
 	}
 	if maintenance && (*backupPath != "" && *restorePath != "" || cfg.portable || cfg.fresh || *openSettings || *diagnostics || *enableWhp || *applyLauncherUpdateFlag || *applyLauncherRollbackFlag) {
@@ -195,6 +203,12 @@ func main() {
 	// code (see setup.go); it must not touch the single-instance port.
 	if *enableWhp {
 		os.Exit(runDismEnable())
+	}
+	if *uninstallFinish {
+		if !explicitFlags["dir"] {
+			os.Exit(2)
+		}
+		os.Exit(finishUninstall(cfg.dir, *updateWaitPID))
 	}
 	// Bind before the first-run location prompt. Two quick launches must not
 	// race each other through the folder choice or write the same pointer and

--- a/app/recovery_windows.go
+++ b/app/recovery_windows.go
@@ -82,6 +82,8 @@ func runRecoveryUI(dir, action string) error {
 		}
 	case "reset":
 		return resetFromSettings(dir)
+	case "uninstall":
+		return runUninstall(dir)
 	default:
 		return fmt.Errorf("unknown recovery action")
 	}

--- a/app/settings_dialog_windows.go
+++ b/app/settings_dialog_windows.go
@@ -66,6 +66,7 @@ const (
 	settingsRenderGPUID  = 2024
 	settingsRenderCPUID  = 2025
 	settingsCPUsID       = 2026
+	settingsUninstallID  = 2027
 	bsAutoradiobutton    = 0x0009
 	wsGroup              = 0x00020000
 	settingsRecoveryDone = 0x8010
@@ -187,6 +188,8 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 				launchRecovery("restore")
 			case settingsResetID:
 				launchRecovery("reset")
+			case settingsUninstallID:
+				launchRecovery("uninstall")
 			}
 			return 0
 		case settingsRecoveryDone:
@@ -222,7 +225,7 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 		return false
 	}
 
-	const clientW, clientH = 480, 650
+	const clientW, clientH = 480, 682
 	rect := [4]int32{0, 0, clientW, clientH}
 	style := uintptr(wsCaption | wsSysmenu)
 	procAdjustWindowRectEx.Call(uintptr(unsafe.Pointer(&rect[0])), style, 0, 0)
@@ -339,7 +342,13 @@ func runSettingsDialog(path, dataDir string, portable bool) (saved bool) {
 	if portable {
 		help = "Backup and recovery controls are available for standard installs."
 	}
-	mk("STATIC", help, left, y, clientW-2*left, 34, ssNoprefix, 0)
+	mk("STATIC", help, left, y, clientW-2*left, 20, ssNoprefix, 0)
+	y += 26
+	uninstallButton := mk("BUTTON", "Remove Try Omarchy...", left, y, 160, 26, wsTabstop, settingsUninstallID)
+	if portable {
+		procEnableWindow.Call(uninstallButton, 0)
+	}
+	mk("STATIC", "Deletes this installation after offering a backup.", left+170, y+5, clientW-2*left-170, 20, ssNoprefix, 0)
 	mk("BUTTON", "Save", clientW-16-180, clientH-40, 84, 26, bsDefpushbutton|wsTabstop, settingsSaveID)
 	mk("BUTTON", "Cancel", clientW-16-84, clientH-40, 84, 26, wsTabstop, settingsCancelID)
 	// Settings is often opened from the tray while the maximized QEMU window

--- a/app/uninstall.go
+++ b/app/uninstall.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// Apps & features registration. One key per installation, so a default
+// install and a copy on another drive can be removed independently.
+const uninstallRegistryParent = `Software\Microsoft\Windows\CurrentVersion\Uninstall`
+
+func uninstallKeyName(dir, defaultDir string) string {
+	if pathsEqual(dir, defaultDir) {
+		return "TryOmarchy"
+	}
+	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimRight(dir, `\/`))))
+	return "TryOmarchy-" + hex.EncodeToString(sum[:4])
+}
+
+func uninstallDisplayName(dir, defaultDir string) string {
+	if pathsEqual(dir, defaultDir) {
+		return "Try Omarchy"
+	}
+	return "Try Omarchy (" + dir + ")"
+}
+
+// uninstallCommand is the string Windows runs from Apps & features. Paths
+// cannot contain double quotes, so quoting each one is enough.
+func uninstallCommand(target, dir string) string {
+	return `"` + target + `" -dir "` + dir + `" -uninstall`
+}
+
+func displayVersion(version string) string {
+	return strings.TrimPrefix(version, "v")
+}

--- a/app/uninstall_test.go
+++ b/app/uninstall_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUninstallKeyNameIsStablePerInstall(t *testing.T) {
+	def := `C:\Users\me\AppData\Local\TryOmarchy`
+	if got := uninstallKeyName(def, def); got != "TryOmarchy" {
+		t.Fatalf("default install key: %q", got)
+	}
+	a := uninstallKeyName(`E:\Omarchy\TryOmarchy`, def)
+	b := uninstallKeyName(`e:\omarchy\tryomarchy\`, def)
+	if a != b || !strings.HasPrefix(a, "TryOmarchy-") || len(a) != len("TryOmarchy-")+8 {
+		t.Fatalf("alternate install keys differ or are malformed: %q %q", a, b)
+	}
+	if uninstallKeyName(`D:\Other`, def) == a {
+		t.Fatal("different folders must not share a key")
+	}
+	if got := uninstallDisplayName(`E:\Omarchy\TryOmarchy`, def); got != `Try Omarchy (E:\Omarchy\TryOmarchy)` {
+		t.Fatalf("display name: %q", got)
+	}
+}
+
+func TestUninstallCommandQuotesPaths(t *testing.T) {
+	got := uninstallCommand(`E:\My Omarchy\TryOmarchy.exe`, `E:\My Omarchy`)
+	if got != `"E:\My Omarchy\TryOmarchy.exe" -dir "E:\My Omarchy" -uninstall` {
+		t.Fatalf("command: %s", got)
+	}
+	if displayVersion("v0.0.12-preview") != "0.0.12-preview" {
+		t.Fatal("display version keeps the v prefix")
+	}
+}

--- a/app/uninstall_windows.go
+++ b/app/uninstall_windows.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+var (
+	procRegCreateKeyExW = advapi32.NewProc("RegCreateKeyExW")
+	procRegSetValueExW  = advapi32.NewProc("RegSetValueExW")
+	procRegDeleteTreeW  = advapi32.NewProc("RegDeleteTreeW")
+)
+
+const (
+	regOptionNonVolatile = 0
+	regSz                = 1
+	regDword             = 4
+)
+
+func defaultDataDirectory() string {
+	return filepath.Join(os.Getenv("LOCALAPPDATA"), defaultDataDirectoryName)
+}
+
+// registerUninstallEntry lists this installation under Apps & features. It
+// runs on every normal launch, so an entry a user removed by hand comes back
+// only while the install still exists, and the recorded launcher path follows
+// the stable copy.
+func registerUninstallEntry(target, dir string) error {
+	defaultDir := defaultDataDirectory()
+	keyPath, _ := syscall.UTF16PtrFromString(uninstallRegistryParent + `\` + uninstallKeyName(dir, defaultDir))
+	var key syscall.Handle
+	var disposition uint32
+	r, _, err := procRegCreateKeyExW.Call(uintptr(syscall.HKEY_CURRENT_USER), uintptr(unsafe.Pointer(keyPath)), 0, 0,
+		regOptionNonVolatile, uintptr(syscall.KEY_WRITE), 0, uintptr(unsafe.Pointer(&key)), uintptr(unsafe.Pointer(&disposition)))
+	if r != 0 {
+		return fmt.Errorf("creating the Apps & features entry: %v", err)
+	}
+	defer syscall.RegCloseKey(key)
+	values := map[string]string{
+		"DisplayName":     uninstallDisplayName(dir, defaultDir),
+		"DisplayVersion":  displayVersion(currentVersion),
+		"Publisher":       "Omacom",
+		"InstallLocation": dir,
+		"DisplayIcon":     target + ",0",
+		"UninstallString": uninstallCommand(target, dir),
+		"URLInfoAbout":    "https://github.com/omacom/try-omarchy-windows",
+		"InstallDate":     time.Now().Format("20060102"),
+	}
+	for name, value := range values {
+		if err := regSetString(key, name, value); err != nil {
+			return err
+		}
+	}
+	for _, name := range []string{"NoModify", "NoRepair"} {
+		if err := regSetDword(key, name, 1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func unregisterUninstallEntry(dir string) error {
+	parent, _ := syscall.UTF16PtrFromString(uninstallRegistryParent)
+	var key syscall.Handle
+	if err := syscall.RegOpenKeyEx(syscall.HKEY_CURRENT_USER, parent, 0, syscall.KEY_WRITE|syscall.KEY_READ, &key); err != nil {
+		return nil
+	}
+	defer syscall.RegCloseKey(key)
+	name, _ := syscall.UTF16PtrFromString(uninstallKeyName(dir, defaultDataDirectory()))
+	r, _, err := procRegDeleteTreeW.Call(uintptr(key), uintptr(unsafe.Pointer(name)))
+	if r != 0 && r != uintptr(syscall.ERROR_FILE_NOT_FOUND) {
+		return fmt.Errorf("removing the Apps & features entry: %v", err)
+	}
+	return nil
+}
+
+func regSetString(key syscall.Handle, name, value string) error {
+	n, _ := syscall.UTF16PtrFromString(name)
+	v, _ := syscall.UTF16FromString(value)
+	r, _, err := procRegSetValueExW.Call(uintptr(key), uintptr(unsafe.Pointer(n)), 0, regSz,
+		uintptr(unsafe.Pointer(&v[0])), uintptr(len(v)*2))
+	if r != 0 {
+		return fmt.Errorf("writing %s: %v", name, err)
+	}
+	return nil
+}
+
+func regSetDword(key syscall.Handle, name string, value uint32) error {
+	n, _ := syscall.UTF16PtrFromString(name)
+	r, _, err := procRegSetValueExW.Call(uintptr(key), uintptr(unsafe.Pointer(n)), 0, regDword,
+		uintptr(unsafe.Pointer(&value)), 4)
+	if r != 0 {
+		return fmt.Errorf("writing %s: %v", name, err)
+	}
+	return nil
+}
+
+// removeLauncherShortcuts deletes the Start menu and Desktop shortcuts that
+// point at this installation's launcher and leaves any other install's alone.
+func removeLauncherShortcuts(target string) error {
+	const script = `$ErrorActionPreference='Stop'; $shell=New-Object -ComObject WScript.Shell; ` +
+		`$programs=[Environment]::GetFolderPath('Programs'); $desktop=[Environment]::GetFolderPath('DesktopDirectory'); ` +
+		`foreach($path in @((Join-Path $programs 'Try Omarchy.lnk'),(Join-Path $programs 'Try Omarchy Settings.lnk'),(Join-Path $desktop 'Try Omarchy.lnk'))) { ` +
+		`if (Test-Path -LiteralPath $path) { $link=$shell.CreateShortcut($path); ` +
+		`if ([StringComparer]::OrdinalIgnoreCase.Equals($link.TargetPath,$env:TRYOMARCHY_SHORTCUT_TARGET)) { Remove-Item -LiteralPath $path -Force } } }`
+	cmd := exec.Command(system32("WindowsPowerShell\\v1.0\\powershell.exe"),
+		"-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script)
+	cmd.Env = append(os.Environ(), "TRYOMARCHY_SHORTCUT_TARGET="+target)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: createNoWindow}
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("removing shortcuts: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// runUninstall removes a stopped standard installation: an optional backup
+// first, then shortcuts, the Apps & features entry, the data-location
+// pointer, and the data folder itself.
+func runUninstall(dir string) error {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return err
+	}
+	if disk := filepath.Join(dir, "vm", "disk.raw"); fileExists(disk) {
+		f, err := openBackupDisk(disk)
+		if err != nil {
+			return fmt.Errorf("close Try Omarchy before removing it: %w", err)
+		}
+		f.Close()
+	}
+	choice := msgBox("Remove Try Omarchy from this PC?\n\nThis deletes the Omarchy virtual disk and everything inside it, the downloaded image and runtime, settings, and the launcher in:\n\n"+dir+"\n\nShortcuts and the Apps & features entry are removed. Windows shared folders and the original download are kept.\n\nCreate a full backup first?\nYes: choose a backup. No: skip the backup. Cancel: keep everything.", mbYesNoCancel|mbIconQuestion|mbDefbutton2)
+	if choice != idYes && choice != idNo {
+		return nil
+	}
+	if choice == idYes {
+		name, ok, err := chooseBackupDestination()
+		if err != nil || !ok {
+			return err
+		}
+		beginRecoveryProgress("Backing up before removal...")
+		err = writeVMBackupProgress(dir, name, recoveryProgress("Backing up"))
+		uiDone()
+		if err != nil {
+			return err
+		}
+	}
+	if msgBox("Remove Try Omarchy and delete "+dir+" now?", mbYesNo|mbIconQuestion|mbDefbutton2) != idYes {
+		return nil
+	}
+	target := filepath.Join(dir, stableLauncherName)
+	if err := removeLauncherShortcuts(target); err != nil {
+		logf("uninstall: %v", err)
+	}
+	if err := unregisterUninstallEntry(dir); err != nil {
+		logf("uninstall: %v", err)
+	}
+	defaultDir := defaultDataDirectory()
+	if pointed, ok, _ := loadDataLocationPointer(defaultDir); ok && pathsEqual(pointed, dir) {
+		os.Remove(dataLocationPointerPath(defaultDir))
+		os.Remove(defaultDir)
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	if rel, err := filepath.Rel(dir, self); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		// This process runs from inside the folder it must delete. A copy
+		// outside the folder finishes the job after this one exits.
+		helper := filepath.Join(os.TempDir(), fmt.Sprintf("TryOmarchy-uninstall-%d.exe", os.Getpid()))
+		if err := copyLauncher(self, helper, replaceLauncher); err != nil {
+			return fmt.Errorf("preparing the removal helper: %w", err)
+		}
+		cmd := exec.Command(helper, "-dir", dir, "-uninstall-finish", "-update-wait-pid", strconv.Itoa(os.Getpid()))
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("starting the removal helper: %w", err)
+		}
+		return nil
+	}
+	if err := removeAllWithRetry(dir); err != nil {
+		return err
+	}
+	infoBox("Try Omarchy was removed.")
+	return nil
+}
+
+// finishUninstall runs from the temporary helper copy: wait for the launcher
+// that started it, delete the folder, report, then schedule its own removal.
+func finishUninstall(dir string, waitPID int) int {
+	if waitPID > 0 {
+		waitForProcess(waitPID)
+	}
+	dir, err := filepath.Abs(dir)
+	if err == nil {
+		err = removeAllWithRetry(dir)
+	}
+	code := 0
+	if err != nil {
+		errorBox("Try Omarchy could not delete its folder:\n\n" + dir + "\n\n" + err.Error() + "\n\nDelete it by hand to finish removing Try Omarchy.")
+		code = 1
+	} else {
+		infoBox("Try Omarchy was removed.")
+	}
+	// Started after the message box closes, so the helper file is no longer
+	// in use by the time cmd deletes it.
+	self, _ := os.Executable()
+	cleanup := exec.Command(system32("cmd.exe"))
+	// Go would escape the inner quotes for cmd, which does not understand
+	// backslash escapes. Hand cmd the exact line; /s strips the outer quotes.
+	cleanup.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: createNoWindow,
+		CmdLine: `"` + system32("cmd.exe") + `" /d /s /c "ping -n 4 127.0.0.1 >nul & del /q "` + self + `""`}
+	_ = cleanup.Start()
+	return code
+}
+
+func fileExists(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode().IsRegular()
+}

--- a/app/winapi.go
+++ b/app/winapi.go
@@ -14,6 +14,7 @@ import (
 var (
 	user32   = syscall.NewLazyDLL("user32.dll")
 	kernel32 = syscall.NewLazyDLL("kernel32.dll")
+	advapi32 = syscall.NewLazyDLL("advapi32.dll")
 
 	procMessageBoxW              = user32.NewProc("MessageBoxW")
 	procSetWindowsHookExW        = user32.NewProc("SetWindowsHookExW")


### PR DESCRIPTION
Removing Try Omarchy meant deleting the data folder by hand and then finding the shortcuts and the data-location pointer yourself. For an app that asks for a Windows feature and a restart on first run, a clean removal is part of trust.

Every normal launch now registers the installation under Apps & features in HKCU, one key per data folder so a default install and a copy on another drive stay independent. The entry carries the version, install location, icon, and an uninstall command that points at that folder's stable launcher.

Removal runs from **Remove Try Omarchy** in Settings, from Apps & features, or from `TryOmarchy.exe -uninstall`. It refuses while the guest disk is open, offers a full backup first, asks once more, then removes only the Start menu and Desktop shortcuts whose target is this install's launcher, this install's registry key, the data-location pointer when it names this folder, and the data folder. When the launcher runs from inside the folder being deleted, a copy in the temp folder waits for it to exit, deletes the folder, reports, and removes itself through cmd.

Tested in the Win11 VM with a throwaway install on E: that had its own Desktop shortcut and registry key beside the real install: folder, shortcut, key, and the temp helper were all gone afterwards and the real install's Start menu shortcut survived. A normal launch of the real install created its Apps & features entry with the expected values. README removal FAQ updated.