### PR TITLE
Seed new guest users without Hyprland toggles switched on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- Automatic rendering now remembers when this PC cannot run the GPU path and goes straight to CPU rendering on later launches, retrying after a runtime or display-driver change, after a week, or when GPU is chosen in the new Rendering setting. A pending runtime update on a PC that already runs on CPU rendering is kept instead of being rolled back and downloaded again on every launch.
+- Guest CPUs and RAM are sized to the machine: all logical processors but two (between two and eight) and a third of the RAM (4 to 8 GiB, up to 12 GiB with GPU rendering), with a Guest CPUs setting and `-cpus` to override.
+- Try Omarchy registers under Windows Apps & features and can be removed from there, from **Remove Try Omarchy** in Settings, or with `-uninstall`. Removal offers a full backup first and deletes only this installation's shortcuts, registry entry, saved location, and data folder.
+
+### Fixes
+- Restore now budgets free space from the backup's compressed size instead of the sparse files' nominal size, so a 10 GB backup no longer demands 33 GB free. Restored files keep the modification times their receipts recorded, so a restored copy does not re-download its image and runtime on first launch, and a restore from Settings no longer asks about shortcuts again.
+- New guest users no longer start with the "no gaps" and "single-window aspect ratio" Hyprland toggles switched on, which silently overrode gaps, border size, and rounding set in `~/.config/hypr/looknfeel.lua` (#32). Existing guests keep their current toggles; run `omarchy-hyprland-window-gaps-toggle` once to turn gaps back on.
+- The Settings text under the SSH key row is no longer painted over by the label above it, and messages logged before the session log opens, such as the restored-payload decision after an interrupted update, now appear at the top of the log.
+
 ## v0.0.12-preview - 2026-09-05
 
 ### Features

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -23,7 +23,7 @@ Try Omarchy runs the full x86_64 Arch Linux environment used by Omarchy. It is n
 - Host-folder sharing is not available with an external stock QEMU fallback.
 - Text clipboard sharing works in both directions. File clipboard and drag and
   drop are not implemented yet; use the shared folder for files.
-- The launcher boots its pinned kernel and initramfs from the release image. Ordinary package installation is supported, but replacing the guest kernel independently can leave it out of sync with those boot files.
+- The launcher boots its pinned kernel and initramfs from the release image, and the guest's pacman configuration holds the `linux` package so `pacman -Syu` and `omarchy-update` leave it alone. Kernel updates arrive with guest-image updates, which also carry the matching modules onto existing disks. Forcing a different kernel package into the guest leaves it out of sync with those boot files.
 - Configuration export and restore are available through `try-omarchy-export`; see [the migration guide](MIGRATION.md). Development builds also support [stopped-VM backup and restore](BACKUP.md) from Settings or command-line options. Reset can retain the old disk and offer a full backup first. Snapshots are not available yet.
 
 Compatibility varies with Windows, CPU, GPU, and driver combinations. When reporting a problem, include those details and whether Try Omarchy selected GPU or CPU rendering.

--- a/guest-build/0033-Seed-only-the-toggle-placeholder-for-new-users.patch
+++ b/guest-build/0033-Seed-only-the-toggle-placeholder-for-new-users.patch
@@ -1,0 +1,50 @@
+From 6dc03449e4f184ee377380d9d8e31c92000d5849 Mon Sep 17 00:00:00 2001
+From: Tyler South <tsouth2@gmail.com>
+Date: Sat, 5 Sep 2026 03:53:26 -0400
+Subject: [PATCH] Seed only the toggle placeholder for new users
+
+materialize-omarchy.sh copied every template from default/hypr/toggles into each new user's toggle state. A file there means the toggle is on and it loads after the user's looknfeel.lua, so window-no-gaps and single-window-aspect-ratio were permanently switched on and overrode gaps, border size, and rounding for everyone (omacom/try-omarchy-windows#32). Seed only flags.lua, which keeps the directory present, matching what omarchy-hyprland-toggle expects.
+---
+ guest/scripts/materialize-omarchy.sh | 8 +++++++-
+ guest/tests/verify.py                | 5 +++++
+ 2 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/guest/scripts/materialize-omarchy.sh b/guest/scripts/materialize-omarchy.sh
+index 7786cce..3754203 100755
+--- a/guest/scripts/materialize-omarchy.sh
++++ b/guest/scripts/materialize-omarchy.sh
+@@ -160,8 +160,14 @@ copy_tree "$nvim_config" "$root/etc/skel/.config/nvim"
+ install_file 0644 "$source_dir/default/bashrc" "$root/etc/skel/.bashrc"
+ mkdir -p "$root/etc/skel/.local/share/applications"
+ copy_contents "$source_dir/applications" "$root/etc/skel/.local/share/applications"
++# A file in the toggle state directory means that toggle is switched on
++# (omarchy-hyprland-toggle copies a template in to enable it), and everything
++# there loads after the user's looknfeel.lua. Seed only the placeholder that
++# keeps the directory present; copying every template turned "no gaps" and
++# "single-window aspect ratio" on for every user and silently overrode their
++# gaps, border, and rounding settings.
+ mkdir -p "$root/etc/skel/.local/state/omarchy/toggles/hypr"
+-copy_contents "$source_dir/default/hypr/toggles" "$root/etc/skel/.local/state/omarchy/toggles/hypr"
++install_file 0644 "$source_dir/default/hypr/toggles/flags.lua" "$root/etc/skel/.local/state/omarchy/toggles/hypr/flags.lua"
+ 
+ if [[ -d $source_dir/default/nautilus-python/extensions ]]; then
+   copy_tree "$source_dir/default/nautilus-python/extensions" "$root/etc/skel/.local/share/nautilus-python/extensions"
+diff --git a/guest/tests/verify.py b/guest/tests/verify.py
+index 3db8c06..dbf1fa0 100755
+--- a/guest/tests/verify.py
++++ b/guest/tests/verify.py
+@@ -114,6 +114,11 @@ def main() -> None:
+     check("factory-overlay" in configure and "native-overlay" in configure, "rootfs receives only native factory overlays")
+     check("omarchy-provision-owner.service" in configure, "first boot uses upstream owner provisioning")
+     materialize = read(GUEST / "scripts/materialize-omarchy.sh")
++    check(
++        'install_file 0644 "$source_dir/default/hypr/toggles/flags.lua" "$root/etc/skel/.local/state/omarchy/toggles/hypr/flags.lua"' in materialize
++        and 'copy_contents "$source_dir/default/hypr/toggles"' not in materialize,
++        "new users start with no Hyprland toggles switched on (only the flags.lua placeholder)",
++    )
+     check(
+         'nvim_config="$root/usr/share/omarchy-nvim/config"' in materialize
+         and 'copy_tree "$nvim_config" "$root/etc/skel/.config/nvim"' in materialize
+-- 
+2.55.0
+

--- a/guest-build/README.md
+++ b/guest-build/README.md
@@ -54,6 +54,10 @@ Windows VM tests unless noted in the release checklist):
   directory under its own name at login, pins it in the Files sidebar, and
   opens each newly selected share once so users can find it immediately; it
   removes only those managed entries on launches that share nothing
+- New users start with no Hyprland toggles switched on. The builder used to
+  copy every toggle template into the user's toggle state, which turned "no
+  gaps" and "single-window aspect ratio" on permanently and overrode the gaps,
+  border, and rounding set in looknfeel.lua (#32)
 - Overlay scripts have unprivileged behavioral tests under guest/tests
 - The initramfs carries those launcher-integration files onto persistent disks
   created by older releases and reports userspace readiness before the Windows


### PR DESCRIPTION
Fixes #32.

The reporter's `looknfeel.lua` edits were correct and were being loaded; something after them set gaps, border size, and rounding back to zero. Reproduced in the VM guest: `hyprctl getoption general:gaps_in` stays at 0 after the edit and a reload, while `general:layout` and `decoration:dim_inactive` from the same snippet do change.

The cause is in the image builder. `materialize-omarchy.sh` copied every template from Omarchy's `default/hypr/toggles` into each new user's `~/.local/state/omarchy/toggles/hypr`. In Omarchy a file in that directory means the toggle is switched on (`omarchy-hyprland-toggle` enables one by copying the template in), and the directory is loaded after the user's own config. So `window-no-gaps` and `single-window-aspect-ratio` were permanently on for every user, and the first one overrides exactly the three settings the reporter changed. Upstream seeds only the `flags.lua` placeholder.

Guest patch 0033 seeds only that placeholder and adds a contract check so the copy cannot come back. Existing guest disks keep their toggle state; running `omarchy-hyprland-window-gaps-toggle` once turns gaps back on, and I confirmed in the guest that the reporter's values then apply (gaps 5, border 1, rounding 5). The changelog entry says so.

Also starts the Unreleased changelog section covering the merged launcher work, and reworks the kernel note in COMPATIBILITY.md: the guest already holds the `linux` package through `IgnorePkg` and kernel updates arrive with guest-image updates, so the old warning about upgrades breaking the boot no longer matches how the image works.

The guest contract tests pass with the patch applied (`scripts/release/build-guest.sh --contract-only`). This changes the guest image, so it takes effect for new users with the next prepared release; no compat revision bump is needed because no overlay file changes.