### PR TITLE
Remember the VM window's size and position between launches

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -634,11 +634,16 @@ func main() {
 	// Launch-UX contract (NOTES.md): guest console sized to the window it will
 	// actually get, so the picture fills it from the first frame.
 	conW, conH := screenSize(cfg.fullscreen)
+	if !cfg.fullscreen {
+		if p := rememberedWindow(cfg.dir); p != nil && !p.Maximized {
+			conW, conH = p.consoleSize()
+		}
+	}
 	cmdline += fmt.Sprintf(" video=%dx%d", conW, conH)
 
 	go runWinKeyHook()
 	go runWinKeyQmp()
-	go runTitleEnforcer(cfg.fullscreen)
+	go runTitleEnforcer(cfg.dir, cfg.fullscreen)
 	go runCursorReleaseGuard()
 	go runCloseGuard()
 	runClipboardBridge()

--- a/app/winapi.go
+++ b/app/winapi.go
@@ -201,6 +201,9 @@ var (
 	enumTitleMaximize *bool
 	enumTitleIcon     uintptr
 	enumTitleCallback = syscall.NewCallback(enumTitleProc)
+	// enumTitleRestore is the remembered placement for this launch; nil keeps
+	// the maximized default.
+	enumTitleRestore *windowPlacement
 )
 
 func enumTitleProc(hwnd, _ uintptr) uintptr {
@@ -216,8 +219,10 @@ func enumTitleProc(hwnd, _ uintptr) uintptr {
 	uiDone()             // the VM window is on screen: the splash's job is over
 	if *enumTitleMaximize {
 		*enumTitleMaximize = false
-		const swMaximize = 3
-		procShowWindow.Call(hwnd, swMaximize)
+		if enumTitleRestore == nil || !applyPlacement(hwnd, enumTitleRestore) {
+			const swMaximize = 3
+			procShowWindow.Call(hwnd, swMaximize)
+		}
 		setTaskbarIdentity(hwnd) // once per window: our taskbar icon + name
 	}
 	if enumTitleIcon != 0 {
@@ -234,8 +239,8 @@ func enumTitleProc(hwnd, _ uintptr) uintptr {
 	return 1
 }
 
-func enforceTitle(pid uint32, maximize *bool, appIcon uintptr) {
-	enumTitlePid, enumTitleMaximize, enumTitleIcon = pid, maximize, appIcon
+func enforceTitle(pid uint32, maximize *bool, appIcon uintptr, restore *windowPlacement) {
+	enumTitlePid, enumTitleMaximize, enumTitleIcon, enumTitleRestore = pid, maximize, appIcon, restore
 	procEnumWindows.Call(enumTitleCallback, 0)
 }
 

--- a/app/window_placement.go
+++ b/app/window_placement.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// windowPlacementFilename remembers where the VM window was last left, so the
+// next launch opens it there instead of maximized on the primary display.
+const windowPlacementFilename = "window-placement.json"
+
+// The window must still be large enough to use and mostly on a display that
+// still exists; otherwise the launch falls back to the maximized default.
+const (
+	minimumRememberedWidth   = 480
+	minimumRememberedHeight  = 320
+	minimumVisibleWidth      = 200
+	minimumVisibleHeight     = 120
+	windowTitleBarHeight     = 31
+	windowPlacementSchemaNow = 1
+)
+
+type screenRect struct{ Left, Top, Right, Bottom int32 }
+
+type windowPlacement struct {
+	Schema int `json:"schema"`
+	// Normal is the window's restored (non-maximized) rectangle in screen
+	// coordinates, the way Windows keeps it in WINDOWPLACEMENT.
+	Normal    screenRect `json:"normal"`
+	Maximized bool       `json:"maximized"`
+	SavedAt   time.Time  `json:"savedAt"`
+}
+
+func (r screenRect) width() int32  { return r.Right - r.Left }
+func (r screenRect) height() int32 { return r.Bottom - r.Top }
+
+func loadWindowPlacement(dir string) (*windowPlacement, error) {
+	data, err := os.ReadFile(filepath.Join(dir, windowPlacementFilename))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxSettingsBytes {
+		return nil, fmt.Errorf("%s is too large", windowPlacementFilename)
+	}
+	var p windowPlacement
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	if p.Schema != windowPlacementSchemaNow {
+		return nil, fmt.Errorf("%s has an unsupported schema", windowPlacementFilename)
+	}
+	return &p, nil
+}
+
+func saveWindowPlacement(dir string, p windowPlacement) error {
+	p.Schema = windowPlacementSchemaNow
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, windowPlacementFilename)
+	tmp := path + ".part"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// usable reports whether the remembered rectangle can be restored on the
+// displays present now. A window left on a monitor that is gone, or shrunk to
+// a sliver, is not worth restoring.
+func (p *windowPlacement) usable(monitors []screenRect) bool {
+	if p == nil {
+		return false
+	}
+	r := p.Normal
+	if r.width() < minimumRememberedWidth || r.height() < minimumRememberedHeight {
+		return false
+	}
+	for _, m := range monitors {
+		left, top := max(r.Left, m.Left), max(r.Top, m.Top)
+		right, bottom := min(r.Right, m.Right), min(r.Bottom, m.Bottom)
+		if right-left >= minimumVisibleWidth && bottom-top >= minimumVisibleHeight {
+			return true
+		}
+	}
+	return false
+}
+
+// sameAs ignores the timestamp so an unchanged window does not rewrite the
+// file every second.
+func (p *windowPlacement) sameAs(o *windowPlacement) bool {
+	return p != nil && o != nil && p.Normal == o.Normal && p.Maximized == o.Maximized
+}
+
+// consoleSize is the guest console resolution that fills the remembered
+// window, so the picture matches the window from the first frame.
+func (p *windowPlacement) consoleSize() (int, int) {
+	return int(p.Normal.width()), int(p.Normal.height()) - windowTitleBarHeight
+}

--- a/app/window_placement_test.go
+++ b/app/window_placement_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWindowPlacementRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if p, err := loadWindowPlacement(dir); err != nil || p != nil {
+		t.Fatalf("missing file should be nil: %v %v", p, err)
+	}
+	want := windowPlacement{Normal: screenRect{100, 50, 1380, 850}, Maximized: false, SavedAt: time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)}
+	if err := saveWindowPlacement(dir, want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadWindowPlacement(dir)
+	if err != nil || got == nil || !got.sameAs(&want) || got.Schema != windowPlacementSchemaNow {
+		t.Fatalf("round trip: %+v %v", got, err)
+	}
+	if w, h := got.consoleSize(); w != 1280 || h != 800-windowTitleBarHeight {
+		t.Fatalf("console size %dx%d", w, h)
+	}
+}
+
+func TestWindowPlacementUsableOnlyOnAPresentDisplay(t *testing.T) {
+	primary := screenRect{0, 0, 1920, 1080}
+	second := screenRect{1920, 0, 3840, 1080}
+	cases := []struct {
+		name  string
+		p     *windowPlacement
+		mons  []screenRect
+		usable bool
+	}{
+		{"nil", nil, []screenRect{primary}, false},
+		{"on primary", &windowPlacement{Normal: screenRect{100, 100, 1300, 900}}, []screenRect{primary}, true},
+		{"on second monitor present", &windowPlacement{Normal: screenRect{2000, 100, 3200, 900}}, []screenRect{primary, second}, true},
+		{"on second monitor gone", &windowPlacement{Normal: screenRect{2000, 100, 3200, 900}}, []screenRect{primary}, false},
+		{"mostly off screen", &windowPlacement{Normal: screenRect{1800, 1000, 3000, 1800}}, []screenRect{primary}, false},
+		{"too small", &windowPlacement{Normal: screenRect{0, 0, 300, 200}}, []screenRect{primary}, false},
+		{"partly off the edge", &windowPlacement{Normal: screenRect{-200, -50, 1000, 700}}, []screenRect{primary}, true},
+	}
+	for _, c := range cases {
+		if got := c.p.usable(c.mons); got != c.usable {
+			t.Errorf("%s: usable=%v, want %v", c.name, got, c.usable)
+		}
+	}
+}

--- a/app/window_placement_windows.go
+++ b/app/window_placement_windows.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	procGetWindowPlacement  = user32.NewProc("GetWindowPlacement")
+	procSetWindowPlacement  = user32.NewProc("SetWindowPlacement")
+	procEnumDisplayMonitors = user32.NewProc("EnumDisplayMonitors")
+	// One callback for the process: syscall.NewCallback never frees its slot.
+	enumMonitorsCallback = syscall.NewCallback(enumMonitorsProc)
+	enumMonitorsResult   []screenRect
+)
+
+const (
+	swShowNormal    = 1
+	swShowMinimized = 2
+	swShowMaximized = 3
+)
+
+type windowPlacementStruct struct {
+	length, flags, showCmd uint32
+	minPosition            [2]int32
+	maxPosition            [2]int32
+	normalPosition         screenRect
+}
+
+func enumMonitorsProc(_, _ uintptr, rect *screenRect, _ uintptr) uintptr {
+	enumMonitorsResult = append(enumMonitorsResult, *rect)
+	return 1
+}
+
+// monitorRects lists the virtual-screen rectangles of every display. Only the
+// title enforcer's goroutine calls it, so the shared result slice needs no lock.
+func monitorRects() []screenRect {
+	enumMonitorsResult = nil
+	procEnumDisplayMonitors.Call(0, 0, enumMonitorsCallback, 0)
+	return append([]screenRect(nil), enumMonitorsResult...)
+}
+
+// capturePlacement reads where the VM window is now. Minimized windows are
+// skipped so a launch never restores into the taskbar.
+func capturePlacement(hwnd uintptr) *windowPlacement {
+	var wp windowPlacementStruct
+	wp.length = uint32(unsafe.Sizeof(wp))
+	if r, _, _ := procGetWindowPlacement.Call(hwnd, uintptr(unsafe.Pointer(&wp))); r == 0 || wp.showCmd == swShowMinimized {
+		return nil
+	}
+	return &windowPlacement{Normal: wp.normalPosition, Maximized: wp.showCmd == swShowMaximized}
+}
+
+// applyPlacement moves the VM window to the remembered rectangle and state.
+func applyPlacement(hwnd uintptr, p *windowPlacement) bool {
+	var wp windowPlacementStruct
+	wp.length = uint32(unsafe.Sizeof(wp))
+	wp.showCmd = swShowNormal
+	if p.Maximized {
+		wp.showCmd = swShowMaximized
+	}
+	wp.normalPosition = p.Normal
+	r, _, _ := procSetWindowPlacement.Call(hwnd, uintptr(unsafe.Pointer(&wp)))
+	return r != 0
+}
+
+// rememberedWindow returns the placement to restore this launch, or nil for
+// the maximized default.
+func rememberedWindow(dir string) *windowPlacement {
+	p, err := loadWindowPlacement(dir)
+	if err != nil {
+		logf("ignoring %s: %v", windowPlacementFilename, err)
+		return nil
+	}
+	if !p.usable(monitorRects()) {
+		return nil
+	}
+	return p
+}

--- a/app/winkey.go
+++ b/app/winkey.go
@@ -145,18 +145,34 @@ func runWinKeyQmp() {
 // when the window first appears, and stamps our icon over QEMU's on the
 // window + taskbar (the SDL window belongs to qemu-system-*.exe, so without
 // this the taskbar shows the QEMU logo - the last piece of QEMU chrome).
-func runTitleEnforcer(fullscreen bool) {
+// It also remembers where the user leaves the window: the placement is saved
+// whenever it changes and restored, in place of the maximized default, on
+// the next windowed launch if that spot is still on a connected display.
+func runTitleEnforcer(dir string, fullscreen bool) {
 	hInst, _, _ := procGetModuleHandleW.Call(0)
 	appIcon, _, _ := procLoadIconW.Call(hInst, 1) // the embedded Omarchy .ico
 	lastPid := uint32(0)
 	maximize := false
+	var restore, last *windowPlacement
+	if !fullscreen {
+		restore = rememberedWindow(dir)
+		last = restore
+	}
 	for {
 		if pid := qemuPid.Load(); pid != 0 {
 			if pid != lastPid {
 				lastPid = pid
 				maximize = !fullscreen
 			}
-			enforceTitle(pid, &maximize, appIcon)
+			enforceTitle(pid, &maximize, appIcon, restore)
+			if hwnd := qemuHwnd.Load(); hwnd != 0 && !fullscreen && !maximize {
+				if now := capturePlacement(hwnd); now != nil && !now.sameAs(last) {
+					now.SavedAt = time.Now()
+					if err := saveWindowPlacement(dir, *now); err == nil {
+						last = now
+					}
+				}
+			}
 		} else {
 			lastPid = 0
 			qemuHwnd.Store(0)


### PR DESCRIPTION
The VM window always opened maximized on the primary display. Anyone who kept it at a fixed size, or on a second monitor, put it back every launch.

The title enforcer already finds the QEMU window every second. It now reads the window's placement on each pass and writes `window-placement.json` in the data folder when it changes (restored rectangle plus whether it is maximized; minimized is ignored). On the next windowed launch, that placement is applied when the window first appears instead of the maximize call, provided the rectangle is at least 480x320 and at least 200x120 of it lies on a display that is connected now. Otherwise the maximized default stays. The guest console resolution on the kernel command line is taken from the remembered window so the first frame fills it. Fullscreen launches neither save nor restore.

The monitor enumeration callback is created once per process, following the existing note about the callback table.

Tested in the Win11 VM: a launch with no file opens maximized; after restoring and moving the window to 100,80 at 1000x700 the file records that rectangle; a launch with a saved placement opens at exactly that rectangle, not maximized, with `video=960x649` on the command line. The placement file was removed from the test install afterwards.