### PR TITLE
Follow the Windows time zone and keyboard layout in the guest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features
 - Automatic rendering now remembers when this PC cannot run the GPU path and goes straight to CPU rendering on later launches, retrying after a runtime or display-driver change, after a week, or when GPU is chosen in the new Rendering setting. A pending runtime update on a PC that already runs on CPU rendering is kept instead of being rolled back and downloaded again on every launch.
 - Guest CPUs and RAM are sized to the machine: all logical processors but two (between two and eight) and a third of the RAM (4 to 8 GiB, up to 12 GiB with GPU rendering), with a Guest CPUs setting and `-cpus` to override.
+- The guest follows the Windows time zone and default keyboard layout. Each is applied when it changes on the Windows side, so a layout or zone chosen inside Omarchy stays until Windows changes; `-timezone` and `-keyboard` override this for a launch. Existing guests gain this with the next guest-image update.
+- The VM window remembers its size and position: a windowed launch reopens where the window was last left when that spot is still on a connected display, with the guest console sized to match.
 - Try Omarchy registers under Windows Apps & features and can be removed from there, from **Remove Try Omarchy** in Settings, or with `-uninstall`. Removal offers a full backup first and deletes only this installation's shortcuts, registry entry, saved location, and data folder.
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ Automatic sizing gives the guest all logical processors but two, between two
 and eight, and a third of the machine's RAM between 4 and 8 GiB (up to 12 GiB
 with GPU rendering), reduced to what Windows can spare at launch.
 
+The guest follows the Windows time zone and default keyboard layout. Each is
+applied inside Omarchy when it changes on the Windows side, so a layout or
+zone chosen inside the guest stays until Windows changes. `-timezone` and
+`-keyboard` override this for a launch: `keep` leaves the guest alone, or give
+an IANA zone such as `Europe/Berlin` and an XKB layout such as `de` or
+`us:intl`.
+
 ### Disk capacity
 
 Open Settings and set **Disk capacity (GiB)**, or launch with `-disk-size 64`.

--- a/app/diagnostics_windows.go
+++ b/app/diagnostics_windows.go
@@ -27,6 +27,8 @@ func hostFacts() map[string]string {
 	if r, _, _ := syscall.NewLazyDLL("ntdll.dll").NewProc("RtlGetVersion").Call(uintptr(unsafe.Pointer(&v))); r == 0 {
 		facts["host.windows"] = fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.build)
 	}
+	facts["host.timeZone"] = hostTimeZoneKey()
+	facts["host.keyboardLayout"] = hostKeyboardLayoutID()
 	total, avail := availMemMiB()
 	facts["host.memoryTotalMiB"] = fmt.Sprint(total)
 	facts["host.memoryAvailableMiB"] = fmt.Sprint(avail)

--- a/app/locale.go
+++ b/app/locale.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+// windowsZoneToIANA maps Windows time zone key names to the IANA zone the
+// guest can use, from CLDR windowsZones.xml (territory 001, first zone).
+// Regenerate from https://github.com/unicode-org/cldr/blob/main/common/supplemental/windowsZones.xml
+// when Windows adds zones.
+var windowsZoneToIANA = map[string]string{
+	"AUS Central Standard Time":       "Australia/Darwin",
+	"AUS Eastern Standard Time":       "Australia/Sydney",
+	"Afghanistan Standard Time":       "Asia/Kabul",
+	"Alaskan Standard Time":           "America/Anchorage",
+	"Aleutian Standard Time":          "America/Adak",
+	"Altai Standard Time":             "Asia/Barnaul",
+	"Arab Standard Time":              "Asia/Riyadh",
+	"Arabian Standard Time":           "Asia/Dubai",
+	"Arabic Standard Time":            "Asia/Baghdad",
+	"Argentina Standard Time":         "America/Buenos_Aires",
+	"Astrakhan Standard Time":         "Europe/Astrakhan",
+	"Atlantic Standard Time":          "America/Halifax",
+	"Aus Central W. Standard Time":    "Australia/Eucla",
+	"Azerbaijan Standard Time":        "Asia/Baku",
+	"Azores Standard Time":            "Atlantic/Azores",
+	"Bahia Standard Time":             "America/Bahia",
+	"Bangladesh Standard Time":        "Asia/Dhaka",
+	"Belarus Standard Time":           "Europe/Minsk",
+	"Bougainville Standard Time":      "Pacific/Bougainville",
+	"Canada Central Standard Time":    "America/Regina",
+	"Cape Verde Standard Time":        "Atlantic/Cape_Verde",
+	"Caucasus Standard Time":          "Asia/Yerevan",
+	"Cen. Australia Standard Time":    "Australia/Adelaide",
+	"Central America Standard Time":   "America/Guatemala",
+	"Central Asia Standard Time":      "Asia/Bishkek",
+	"Central Brazilian Standard Time": "America/Cuiaba",
+	"Central Europe Standard Time":    "Europe/Budapest",
+	"Central European Standard Time":  "Europe/Warsaw",
+	"Central Pacific Standard Time":   "Pacific/Guadalcanal",
+	"Central Standard Time":           "America/Chicago",
+	"Central Standard Time (Mexico)":  "America/Mexico_City",
+	"Chatham Islands Standard Time":   "Pacific/Chatham",
+	"China Standard Time":             "Asia/Shanghai",
+	"Cuba Standard Time":              "America/Havana",
+	"Dateline Standard Time":          "Etc/GMT+12",
+	"E. Africa Standard Time":         "Africa/Nairobi",
+	"E. Australia Standard Time":      "Australia/Brisbane",
+	"E. Europe Standard Time":         "Europe/Chisinau",
+	"E. South America Standard Time":  "America/Sao_Paulo",
+	"Easter Island Standard Time":     "Pacific/Easter",
+	"Eastern Standard Time":           "America/New_York",
+	"Eastern Standard Time (Mexico)":  "America/Cancun",
+	"Egypt Standard Time":             "Africa/Cairo",
+	"Ekaterinburg Standard Time":      "Asia/Yekaterinburg",
+	"FLE Standard Time":               "Europe/Kiev",
+	"Fiji Standard Time":              "Pacific/Fiji",
+	"GMT Standard Time":               "Europe/London",
+	"GTB Standard Time":               "Europe/Bucharest",
+	"Georgian Standard Time":          "Asia/Tbilisi",
+	"Greenland Standard Time":         "America/Godthab",
+	"Greenwich Standard Time":         "Atlantic/Reykjavik",
+	"Haiti Standard Time":             "America/Port-au-Prince",
+	"Hawaiian Standard Time":          "Pacific/Honolulu",
+	"India Standard Time":             "Asia/Calcutta",
+	"Iran Standard Time":              "Asia/Tehran",
+	"Israel Standard Time":            "Asia/Jerusalem",
+	"Jordan Standard Time":            "Asia/Amman",
+	"Kaliningrad Standard Time":       "Europe/Kaliningrad",
+	"Korea Standard Time":             "Asia/Seoul",
+	"Libya Standard Time":             "Africa/Tripoli",
+	"Line Islands Standard Time":      "Pacific/Kiritimati",
+	"Lord Howe Standard Time":         "Australia/Lord_Howe",
+	"Magadan Standard Time":           "Asia/Magadan",
+	"Magallanes Standard Time":        "America/Punta_Arenas",
+	"Marquesas Standard Time":         "Pacific/Marquesas",
+	"Mauritius Standard Time":         "Indian/Mauritius",
+	"Middle East Standard Time":       "Asia/Beirut",
+	"Montevideo Standard Time":        "America/Montevideo",
+	"Morocco Standard Time":           "Africa/Casablanca",
+	"Mountain Standard Time":          "America/Denver",
+	"Mountain Standard Time (Mexico)": "America/Mazatlan",
+	"Myanmar Standard Time":           "Asia/Rangoon",
+	"N. Central Asia Standard Time":   "Asia/Novosibirsk",
+	"Namibia Standard Time":           "Africa/Windhoek",
+	"Nepal Standard Time":             "Asia/Katmandu",
+	"New Zealand Standard Time":       "Pacific/Auckland",
+	"Newfoundland Standard Time":      "America/St_Johns",
+	"Norfolk Standard Time":           "Pacific/Norfolk",
+	"North Asia East Standard Time":   "Asia/Irkutsk",
+	"North Asia Standard Time":        "Asia/Krasnoyarsk",
+	"North Korea Standard Time":       "Asia/Pyongyang",
+	"Omsk Standard Time":              "Asia/Omsk",
+	"Pacific SA Standard Time":        "America/Santiago",
+	"Pacific Standard Time":           "America/Los_Angeles",
+	"Pacific Standard Time (Mexico)":  "America/Tijuana",
+	"Pakistan Standard Time":          "Asia/Karachi",
+	"Paraguay Standard Time":          "America/Asuncion",
+	"Qyzylorda Standard Time":         "Asia/Qyzylorda",
+	"Romance Standard Time":           "Europe/Paris",
+	"Russia Time Zone 10":             "Asia/Srednekolymsk",
+	"Russia Time Zone 11":             "Asia/Kamchatka",
+	"Russia Time Zone 3":              "Europe/Samara",
+	"Russian Standard Time":           "Europe/Moscow",
+	"SA Eastern Standard Time":        "America/Cayenne",
+	"SA Pacific Standard Time":        "America/Bogota",
+	"SA Western Standard Time":        "America/La_Paz",
+	"SE Asia Standard Time":           "Asia/Bangkok",
+	"Saint Pierre Standard Time":      "America/Miquelon",
+	"Sakhalin Standard Time":          "Asia/Sakhalin",
+	"Samoa Standard Time":             "Pacific/Apia",
+	"Sao Tome Standard Time":          "Africa/Sao_Tome",
+	"Saratov Standard Time":           "Europe/Saratov",
+	"Singapore Standard Time":         "Asia/Singapore",
+	"South Africa Standard Time":      "Africa/Johannesburg",
+	"South Sudan Standard Time":       "Africa/Juba",
+	"Sri Lanka Standard Time":         "Asia/Colombo",
+	"Sudan Standard Time":             "Africa/Khartoum",
+	"Syria Standard Time":             "Asia/Damascus",
+	"Taipei Standard Time":            "Asia/Taipei",
+	"Tasmania Standard Time":          "Australia/Hobart",
+	"Tocantins Standard Time":         "America/Araguaina",
+	"Tokyo Standard Time":             "Asia/Tokyo",
+	"Tomsk Standard Time":             "Asia/Tomsk",
+	"Tonga Standard Time":             "Pacific/Tongatapu",
+	"Transbaikal Standard Time":       "Asia/Chita",
+	"Turkey Standard Time":            "Europe/Istanbul",
+	"Turks And Caicos Standard Time":  "America/Grand_Turk",
+	"US Eastern Standard Time":        "America/Indianapolis",
+	"US Mountain Standard Time":       "America/Phoenix",
+	"UTC":                             "Etc/UTC",
+	"UTC+12":                          "Etc/GMT-12",
+	"UTC+13":                          "Etc/GMT-13",
+	"UTC-02":                          "Etc/GMT+2",
+	"UTC-08":                          "Etc/GMT+8",
+	"UTC-09":                          "Etc/GMT+9",
+	"UTC-11":                          "Etc/GMT+11",
+	"Ulaanbaatar Standard Time":       "Asia/Ulaanbaatar",
+	"Venezuela Standard Time":         "America/Caracas",
+	"Vladivostok Standard Time":       "Asia/Vladivostok",
+	"Volgograd Standard Time":         "Europe/Volgograd",
+	"W. Australia Standard Time":      "Australia/Perth",
+	"W. Central Africa Standard Time": "Africa/Lagos",
+	"W. Europe Standard Time":         "Europe/Berlin",
+	"W. Mongolia Standard Time":       "Asia/Hovd",
+	"West Asia Standard Time":         "Asia/Tashkent",
+	"West Bank Standard Time":         "Asia/Hebron",
+	"West Pacific Standard Time":      "Pacific/Port_Moresby",
+	"Yakutsk Standard Time":           "Asia/Yakutsk",
+	"Yukon Standard Time":             "America/Whitehorse",
+}
+
+// keyboardLayoutForKLID maps a Windows keyboard layout identifier (the
+// eight-digit KLID from the user's Preload list) to an XKB layout and
+// variant. Full identifiers take precedence over the language in the low
+// sixteen bits, so US-International and Dvorak are told apart from plain US.
+var keyboardLayoutForKLID = map[string][2]string{
+	"00010409": {"us", "dvorak"},
+	"00020409": {"us", "intl"},
+	"00030409": {"us", "dvorak-l"},
+	"00040409": {"us", "dvorak-r"},
+	"00050409": {"us", "dvp"},
+	"00000452": {"gb", ""},
+	"00011809": {"ie", ""},
+	"0001080c": {"be", ""},
+	"00010407": {"de", "T3"},
+	"0001040c": {"fr", "bepo"},
+	"0001041b": {"sk", "qwerty"},
+	"00010405": {"cz", "qwerty"},
+	"00010415": {"pl", "qwertz"},
+	"00010419": {"ru", "typewriter"},
+}
+
+var keyboardLayoutForLanguage = map[string][2]string{
+	"0409": {"us", ""}, "0809": {"gb", ""}, "0c09": {"us", ""}, "1009": {"us", ""}, "1409": {"us", ""},
+	"1809": {"ie", ""}, "1c09": {"za", ""}, "4009": {"in", "eng"},
+	"0407": {"de", ""}, "0807": {"ch", ""}, "0c07": {"at", ""},
+	"040c": {"fr", ""}, "080c": {"be", ""}, "0c0c": {"ca", ""}, "100c": {"ch", "fr"}, "140c": {"lu", ""},
+	"0410": {"it", ""}, "0810": {"ch", "it"},
+	"0c0a": {"es", ""}, "040a": {"es", ""}, "080a": {"latam", ""}, "100a": {"latam", ""}, "180a": {"latam", ""},
+	"200a": {"latam", ""}, "240a": {"latam", ""}, "280a": {"latam", ""}, "2c0a": {"latam", ""}, "300a": {"latam", ""},
+	"340a": {"latam", ""}, "380a": {"latam", ""}, "3c0a": {"latam", ""}, "400a": {"latam", ""}, "440a": {"latam", ""},
+	"480a": {"latam", ""}, "4c0a": {"latam", ""}, "500a": {"latam", ""},
+	"0416": {"br", ""}, "0816": {"pt", ""},
+	"0413": {"us", "intl"}, "0813": {"be", ""},
+	"041d": {"se", ""}, "0414": {"no", ""}, "0814": {"no", ""}, "0406": {"dk", ""}, "040b": {"fi", ""}, "040f": {"is", ""},
+	"0415": {"pl", ""}, "0405": {"cz", ""}, "041b": {"sk", ""}, "040e": {"hu", ""}, "0418": {"ro", ""},
+	"0424": {"si", ""}, "041a": {"hr", ""}, "081a": {"rs", "latin"}, "0c1a": {"rs", ""}, "141a": {"ba", ""}, "042f": {"mk", ""},
+	"0402": {"bg", ""}, "0419": {"ru", ""}, "0422": {"ua", ""}, "0423": {"by", ""},
+	"0425": {"ee", ""}, "0426": {"lv", ""}, "0427": {"lt", ""},
+	"0408": {"gr", ""}, "041f": {"tr", ""}, "042c": {"az", ""}, "0437": {"ge", ""}, "042b": {"am", ""},
+	"040d": {"il", ""}, "0401": {"ara", ""}, "0429": {"ir", ""}, "0420": {"pk", ""}, "0439": {"in", ""},
+	"041e": {"th", ""}, "042a": {"vn", ""}, "0411": {"jp", ""}, "0412": {"kr", ""},
+	"0804": {"cn", ""}, "0404": {"tw", ""}, "0c04": {"cn", ""}, "1004": {"cn", ""}, "1404": {"cn", ""},
+	"043f": {"kz", ""}, "0443": {"uz", ""}, "0440": {"kg", ""}, "0450": {"mn", ""},
+}
+
+var (
+	validZoneName    = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_+./-]{0,63}$`)
+	validLayoutName  = regexp.MustCompile(`^[a-z]{2,8}$`)
+	validVariantName = regexp.MustCompile(`^[A-Za-z0-9_-]{0,32}$`)
+)
+
+// ianaZoneForWindows returns the IANA zone for a Windows time zone key name,
+// or "" when the name is unknown.
+func ianaZoneForWindows(key string) string {
+	zone := windowsZoneToIANA[strings.TrimSpace(key)]
+	if !validZoneName.MatchString(zone) {
+		return ""
+	}
+	return zone
+}
+
+// xkbForKLID returns the XKB layout and variant for a Windows keyboard layout
+// identifier, or "" when the identifier is unknown.
+func xkbForKLID(klid string) (string, string) {
+	klid = strings.ToLower(strings.TrimSpace(klid))
+	if len(klid) != 8 {
+		return "", ""
+	}
+	if m, ok := keyboardLayoutForKLID[klid]; ok {
+		return m[0], m[1]
+	}
+	if m, ok := keyboardLayoutForLanguage[klid[4:]]; ok {
+		return m[0], m[1]
+	}
+	return "", ""
+}
+
+// hostLocaleCmdline builds the kernel parameters that tell the guest which
+// time zone and keyboard layout Windows uses. Unknown values add nothing, so
+// the guest keeps whatever it has.
+func hostLocaleCmdline(zone, layout, variant string) string {
+	words := ""
+	if zone != "" && validZoneName.MatchString(zone) {
+		words += " tryomarchy.tz=" + zone
+	}
+	if layout != "" && validLayoutName.MatchString(layout) && validVariantName.MatchString(variant) {
+		words += " tryomarchy.kb=" + layout
+		if variant != "" {
+			words += ":" + variant
+		}
+	}
+	return words
+}
+
+// splitKeyboardSpec parses "layout" or "layout:variant" as given on the
+// command line or in settings.
+func splitKeyboardSpec(spec string) (string, string) {
+	layout, variant, _ := strings.Cut(strings.TrimSpace(spec), ":")
+	return layout, variant
+}

--- a/app/locale_test.go
+++ b/app/locale_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIANAZoneForWindowsUsesTheCLDRTable(t *testing.T) {
+	for key, want := range map[string]string{
+		"Eastern Standard Time": "America/New_York", "W. Europe Standard Time": "Europe/Berlin",
+		"UTC": "Etc/UTC", "Tokyo Standard Time": "Asia/Tokyo", "AUS Eastern Standard Time": "Australia/Sydney",
+		"Nowhere Standard Time": "", "": "",
+	} {
+		if got := ianaZoneForWindows(key); got != want {
+			t.Errorf("%q: got %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestXKBForKLIDPrefersFullIdentifiers(t *testing.T) {
+	for klid, want := range map[string][2]string{
+		"00000409": {"us", ""}, "00020409": {"us", "intl"}, "00010409": {"us", "dvorak"},
+		"00000407": {"de", ""}, "0000040C": {"fr", ""}, "00000809": {"gb", ""}, "00000416": {"br", ""},
+		"0000080a": {"latam", ""}, "00000419": {"ru", ""}, "00000411": {"jp", ""},
+		"0000ffff": {"", ""}, "409": {"", ""}, "": {"", ""},
+	} {
+		layout, variant := xkbForKLID(klid)
+		if layout != want[0] || variant != want[1] {
+			t.Errorf("%q: got %q/%q, want %q/%q", klid, layout, variant, want[0], want[1])
+		}
+	}
+}
+
+func TestHostLocaleCmdlineOnlyCarriesValidValues(t *testing.T) {
+	if got := hostLocaleCmdline("America/New_York", "de", ""); got != " tryomarchy.tz=America/New_York tryomarchy.kb=de" {
+		t.Fatalf("plain: %q", got)
+	}
+	if got := hostLocaleCmdline("Europe/Berlin", "us", "intl"); got != " tryomarchy.tz=Europe/Berlin tryomarchy.kb=us:intl" {
+		t.Fatalf("variant: %q", got)
+	}
+	if got := hostLocaleCmdline("", "", ""); got != "" {
+		t.Fatalf("empty: %q", got)
+	}
+	for _, bad := range []string{"../etc", "us us", "a b", "Etc UTC", "us;rm"} {
+		for _, got := range []string{hostLocaleCmdline(bad, "us", ""), hostLocaleCmdline("Etc/UTC", bad, ""), hostLocaleCmdline("Etc/UTC", "us", bad)} {
+			if strings.Contains(got, bad) {
+				t.Errorf("unsafe value %q reached the command line: %q", bad, got)
+			}
+		}
+	}
+	if got := hostLocaleCmdline("../etc", "us", ""); got != " tryomarchy.kb=us" {
+		t.Fatalf("a bad zone must not drop the keyboard: %q", got)
+	}
+}
+
+func TestSplitKeyboardSpec(t *testing.T) {
+	for spec, want := range map[string][2]string{"de": {"de", ""}, " us:intl ": {"us", "intl"}, "": {"", ""}} {
+		layout, variant := splitKeyboardSpec(spec)
+		if layout != want[0] || variant != want[1] {
+			t.Errorf("%q: got %q/%q", spec, layout, variant)
+		}
+	}
+}

--- a/app/locale_windows.go
+++ b/app/locale_windows.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"syscall"
+)
+
+// hostTimeZoneKey reads the Windows time zone key name, for example
+// "Eastern Standard Time", which the CLDR table maps to an IANA zone.
+func hostTimeZoneKey() string {
+	path, _ := syscall.UTF16PtrFromString(`SYSTEM\CurrentControlSet\Control\TimeZoneInformation`)
+	var key syscall.Handle
+	if syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE, path, 0, syscall.KEY_READ, &key) != nil {
+		return ""
+	}
+	defer syscall.RegCloseKey(key)
+	return registryString(key, "TimeZoneKeyName")
+}
+
+// hostKeyboardLayoutID reads the user's default input language as the
+// eight-digit keyboard layout identifier at the head of the Preload list.
+func hostKeyboardLayoutID() string {
+	path, _ := syscall.UTF16PtrFromString(`Keyboard Layout\Preload`)
+	var key syscall.Handle
+	if syscall.RegOpenKeyEx(syscall.HKEY_CURRENT_USER, path, 0, syscall.KEY_READ, &key) != nil {
+		return ""
+	}
+	defer syscall.RegCloseKey(key)
+	return registryString(key, "1")
+}
+
+// hostLocale resolves what the guest should follow, honoring the explicit
+// overrides: "" follows Windows, "keep" leaves the guest alone, anything else
+// is used as given.
+func hostLocale(zoneOverride, keyboardOverride string) (zone, layout, variant string) {
+	switch zoneOverride {
+	case "":
+		zone = ianaZoneForWindows(hostTimeZoneKey())
+	case "keep":
+	default:
+		zone = zoneOverride
+	}
+	switch keyboardOverride {
+	case "":
+		layout, variant = xkbForKLID(hostKeyboardLayoutID())
+	case "keep":
+	default:
+		layout, variant = splitKeyboardSpec(keyboardOverride)
+	}
+	return zone, layout, variant
+}

--- a/app/main.go
+++ b/app/main.go
@@ -138,6 +138,8 @@ func main() {
 	flag.IntVar(&cfg.diskGiB, "disk-size", 0, "guest disk capacity in GiB (0: default; grows existing standard disks, never shrinks)")
 	flag.BoolVar(&cfg.noGpu, "nogpu", false, "force CPU rendering even if WINQ-EMU is installed (same as -render cpu)")
 	renderFlag := flag.String("render", "", "rendering path: auto (default), gpu, or cpu")
+	timeZoneFlag := flag.String("timezone", "", "guest time zone: blank follows Windows, keep leaves the guest alone, or an IANA name such as Europe/Berlin")
+	keyboardFlag := flag.String("keyboard", "", "guest keyboard layout: blank follows Windows, keep leaves the guest alone, or an XKB layout such as de or us:intl")
 	flag.BoolVar(&cfg.hostCursor, "host-cursor", false, "force the legacy Windows cursor over the guest")
 	flag.BoolVar(&cfg.instant, "instant", false, "skip first-boot questions and use the trial account")
 	flag.BoolVar(&cfg.portable, "portable", false, "run entirely from data and payload folders beside the executable")
@@ -591,6 +593,11 @@ func main() {
 	}
 	cmdline += sshCmdline(cfg.forwards, cfg.sshKey)
 	cmdline += shareCmdline(cfg.share)
+	zone, layout, variant := hostLocale(*timeZoneFlag, *keyboardFlag)
+	if words := hostLocaleCmdline(zone, layout, variant); words != "" {
+		cmdline += words
+		logf("guest follows Windows locale:%s", words)
+	}
 
 	if err := prepareDisk(cfg, spec.Runtime.Storage.ExpandedSizeMiB); err != nil {
 		if finishSetupCancellation(cfg, err) {

--- a/app/window_placement_test.go
+++ b/app/window_placement_test.go
@@ -27,9 +27,9 @@ func TestWindowPlacementUsableOnlyOnAPresentDisplay(t *testing.T) {
 	primary := screenRect{0, 0, 1920, 1080}
 	second := screenRect{1920, 0, 3840, 1080}
 	cases := []struct {
-		name  string
-		p     *windowPlacement
-		mons  []screenRect
+		name   string
+		p      *windowPlacement
+		mons   []screenRect
 		usable bool
 	}{
 		{"nil", nil, []screenRect{primary}, false},

--- a/guest-build/0034-Follow-the-Windows-time-zone-and-keyboard-layout.patch
+++ b/guest-build/0034-Follow-the-Windows-time-zone-and-keyboard-layout.patch
@@ -1,0 +1,234 @@
+From b681c6813b25996c4f377c1f4fac81a201fc9f54 Mon Sep 17 00:00:00 2001
+From: Tyler South <tsouth2@gmail.com>
+Date: Sat, 5 Sep 2026 04:06:59 -0400
+Subject: [PATCH] Follow the Windows time zone and keyboard layout
+
+The launcher passes tryomarchy.tz=Area/City and tryomarchy.kb=layout[:variant] on the kernel command line. A sysinit service applies each value when it differs from the one applied last, so a change made inside the guest survives until Windows itself changes. The time zone becomes the /etc/localtime link; the keyboard layout goes into /etc/vconsole.conf as XKBLAYOUT and XKBVARIANT, which Omarchy's Hyprland input config already reads. The service ships in the compat overlay so existing disks gain it; the integration revision moves to 6.
+---
+ .../try-omarchy-host-locale.service           |  1 +
+ .../system/try-omarchy-host-locale.service    | 12 ++++
+ .../local/lib/try-omarchy/apply-host-locale   | 64 +++++++++++++++++++
+ guest/scripts/finalize-rootfs.sh              |  5 +-
+ guest/tests/test_overlay_scripts.py           | 58 +++++++++++++++++
+ guest/tests/verify.py                         |  4 +-
+ 6 files changed, 142 insertions(+), 2 deletions(-)
+ create mode 120000 guest/factory-overlay/etc/systemd/system/sysinit.target.wants/try-omarchy-host-locale.service
+ create mode 100644 guest/factory-overlay/etc/systemd/system/try-omarchy-host-locale.service
+ create mode 100755 guest/factory-overlay/usr/local/lib/try-omarchy/apply-host-locale
+
+diff --git a/guest/factory-overlay/etc/systemd/system/sysinit.target.wants/try-omarchy-host-locale.service b/guest/factory-overlay/etc/systemd/system/sysinit.target.wants/try-omarchy-host-locale.service
+new file mode 120000
+index 0000000..4b031e7
+--- /dev/null
++++ b/guest/factory-overlay/etc/systemd/system/sysinit.target.wants/try-omarchy-host-locale.service
+@@ -0,0 +1 @@
++../try-omarchy-host-locale.service
+\ No newline at end of file
+diff --git a/guest/factory-overlay/etc/systemd/system/try-omarchy-host-locale.service b/guest/factory-overlay/etc/systemd/system/try-omarchy-host-locale.service
+new file mode 100644
+index 0000000..9b9ff68
+--- /dev/null
++++ b/guest/factory-overlay/etc/systemd/system/try-omarchy-host-locale.service
+@@ -0,0 +1,12 @@
++[Unit]
++Description=Follow the Windows time zone and keyboard layout reported by Try Omarchy
++DefaultDependencies=no
++After=local-fs.target
++Before=sysinit.target display-manager.service systemd-vconsole-setup.service
++
++[Service]
++Type=oneshot
++ExecStart=/usr/local/lib/try-omarchy/apply-host-locale
++
++[Install]
++WantedBy=sysinit.target
+diff --git a/guest/factory-overlay/usr/local/lib/try-omarchy/apply-host-locale b/guest/factory-overlay/usr/local/lib/try-omarchy/apply-host-locale
+new file mode 100755
+index 0000000..dc75a59
+--- /dev/null
++++ b/guest/factory-overlay/usr/local/lib/try-omarchy/apply-host-locale
+@@ -0,0 +1,64 @@
++#!/bin/bash
++# Follows the Windows time zone and keyboard layout the launcher reports on
++# the kernel command line (tryomarchy.tz=Area/City, tryomarchy.kb=layout or
++# layout:variant). Each value is applied when it differs from the one applied
++# last, so a change made inside the guest survives until Windows itself
++# changes. Omarchy's Hyprland input config reads XKBLAYOUT and XKBVARIANT
++# from /etc/vconsole.conf, so writing that file is enough for the desktop.
++set -euo pipefail
++
++cmdline_file=${TRY_OMARCHY_CMDLINE:-/proc/cmdline}
++state_dir=${TRY_OMARCHY_STATE_DIR:-/var/lib/try-omarchy}
++zoneinfo=${TRY_OMARCHY_ZONEINFO:-/usr/share/zoneinfo}
++localtime=${TRY_OMARCHY_LOCALTIME:-/etc/localtime}
++vconsole=${TRY_OMARCHY_VCONSOLE:-/etc/vconsole.conf}
++
++zone=""
++keyboard=""
++for word in $(<"$cmdline_file"); do
++  case $word in
++    tryomarchy.tz=*) zone=${word#tryomarchy.tz=} ;;
++    tryomarchy.kb=*) keyboard=${word#tryomarchy.kb=} ;;
++  esac
++done
++
++mkdir -p "$state_dir"
++
++apply_zone() {
++  local zone=$1 marker="$state_dir/host-timezone"
++  [[ $zone =~ ^[A-Za-z][A-Za-z0-9_+./-]{0,63}$ && $zone != *..* ]] || { echo "ignoring an invalid time zone on the kernel command line" >&2; return 0; }
++  [[ "$(cat "$marker" 2>/dev/null || true)" != "$zone" ]] || return 0
++  if [[ ! -f $zoneinfo/$zone ]]; then
++    echo "time zone $zone is not installed in the guest" >&2
++    return 0
++  fi
++  ln -sfn "$zoneinfo/$zone" "$localtime"
++  printf '%s\n' "$zone" >"$marker"
++  echo "time zone set to $zone from Windows"
++}
++
++apply_keyboard() {
++  local spec=$1 marker="$state_dir/host-keyboard" layout variant
++  layout=${spec%%:*}
++  variant=""
++  [[ $spec == *:* ]] && variant=${spec#*:}
++  [[ $layout =~ ^[a-z]{2,8}$ && $variant =~ ^[A-Za-z0-9_-]{0,32}$ ]] || { echo "ignoring an invalid keyboard layout on the kernel command line" >&2; return 0; }
++  [[ "$(cat "$marker" 2>/dev/null || true)" != "$spec" ]] || return 0
++  local tmp
++  tmp=$(mktemp "$(dirname "$vconsole")/.vconsole.XXXXXX")
++  if [[ -f $vconsole ]]; then
++    grep -v '^XKBLAYOUT=\|^XKBVARIANT=' "$vconsole" >"$tmp" || true
++  fi
++  printf 'XKBLAYOUT=%s\n' "$layout" >>"$tmp"
++  if [[ -n $variant ]]; then
++    printf 'XKBVARIANT=%s\n' "$variant" >>"$tmp"
++  fi
++  chmod 0644 "$tmp"
++  mv -f "$tmp" "$vconsole"
++  printf '%s\n' "$spec" >"$marker"
++  echo "keyboard layout set to $spec from Windows"
++}
++
++[[ -z $zone ]] || apply_zone "$zone"
++[[ -z $keyboard ]] || apply_keyboard "$keyboard"
++exit 0
+diff --git a/guest/scripts/finalize-rootfs.sh b/guest/scripts/finalize-rootfs.sh
+index 3040870..a1de599 100755
+--- a/guest/scripts/finalize-rootfs.sh
++++ b/guest/scripts/finalize-rootfs.sh
+@@ -61,11 +61,14 @@ compat_paths=(
+   etc/systemd/system/multi-user.target.wants/try-omarchy-ready.service
+   etc/systemd/system/try-omarchy-sshd.service
+   etc/systemd/system/multi-user.target.wants/try-omarchy-sshd.service
++  etc/systemd/system/try-omarchy-host-locale.service
++  etc/systemd/system/sysinit.target.wants/try-omarchy-host-locale.service
+   etc/systemd/user/try-omarchy-share-link.service
+   etc/systemd/user/graphical-session.target.wants/try-omarchy-share-link.service
+   etc/systemd/user/try-omarchy-factory-update-notice.service
+   etc/systemd/user/graphical-session.target.wants/try-omarchy-factory-update-notice.service
+   usr/local/bin/try-omarchy-export
++  usr/local/lib/try-omarchy/apply-host-locale
+   usr/local/lib/try-omarchy/guest-ready
+   usr/local/lib/try-omarchy/request-sshd
+   usr/local/lib/try-omarchy/share-link
+@@ -79,7 +82,7 @@ kernel_release=$(find /usr/lib/modules -mindepth 1 -maxdepth 1 -type d -printf '
+ }
+ # Bump this revision whenever compat-overlay.tar changes in a way that must be
+ # applied to persistent disks created by an earlier launcher release.
+-compat_revision=5
++compat_revision=6
+ printf '%s:%s\n' "$compat_revision" "$kernel_release" >/usr/share/try-omarchy/compat-version
+ 
+ # Never let the container host's hardware autodetection remove the virtual
+diff --git a/guest/tests/test_overlay_scripts.py b/guest/tests/test_overlay_scripts.py
+index e5cc93f..8cd7a11 100644
+--- a/guest/tests/test_overlay_scripts.py
++++ b/guest/tests/test_overlay_scripts.py
+@@ -17,6 +17,7 @@ from pathlib import Path
+ OVERLAY = Path(__file__).resolve().parents[1] / "factory-overlay"
+ SHARE_LINK = OVERLAY / "usr/local/lib/try-omarchy/share-link"
+ REQUEST_SSHD = OVERLAY / "usr/local/lib/try-omarchy/request-sshd"
++HOST_LOCALE = OVERLAY / "usr/local/lib/try-omarchy/apply-host-locale"
+ EXPORT = OVERLAY / "usr/local/bin/try-omarchy-export"
+ 
+ def generated_key(directory: Path) -> str:
+@@ -322,3 +323,60 @@ class ExportTests(OverlayCase):
+ 
+ if __name__ == "__main__":
+     unittest.main()
++
++
++class HostLocaleTests(OverlayCase):
++    def setUp(self) -> None:
++        super().setUp()
++        self.state = self.root / "state"
++        self.zoneinfo = self.root / "zoneinfo"
++        (self.zoneinfo / "America").mkdir(parents=True)
++        (self.zoneinfo / "America/New_York").write_text("TZif")
++        (self.zoneinfo / "Europe").mkdir()
++        (self.zoneinfo / "Europe/Berlin").write_text("TZif")
++        self.localtime = self.root / "localtime"
++        self.localtime.symlink_to(self.zoneinfo / "UTC")
++        self.vconsole = self.root / "vconsole.conf"
++        self.vconsole.write_text("KEYMAP=us\n")
++
++    def apply(self, cmdline: str) -> subprocess.CompletedProcess:
++        return self.run_script(HOST_LOCALE, cmdline=cmdline, TRY_OMARCHY_STATE_DIR=str(self.state),
++                               TRY_OMARCHY_ZONEINFO=str(self.zoneinfo), TRY_OMARCHY_LOCALTIME=str(self.localtime),
++                               TRY_OMARCHY_VCONSOLE=str(self.vconsole))
++
++    def test_applies_zone_and_keyboard_from_the_command_line(self) -> None:
++        result = self.apply("root=/dev/vda tryomarchy.tz=America/New_York tryomarchy.kb=de:nodeadkeys quiet")
++        self.assertEqual(result.returncode, 0, result.stderr)
++        self.assertEqual(os.readlink(self.localtime), str(self.zoneinfo / "America/New_York"))
++        self.assertEqual(self.vconsole.read_text(), "KEYMAP=us\nXKBLAYOUT=de\nXKBVARIANT=nodeadkeys\n")
++        self.assertEqual((self.state / "host-timezone").read_text().strip(), "America/New_York")
++        self.assertEqual((self.state / "host-keyboard").read_text().strip(), "de:nodeadkeys")
++
++    def test_guest_changes_survive_until_windows_changes(self) -> None:
++        self.apply("tryomarchy.tz=America/New_York tryomarchy.kb=de")
++        self.localtime.unlink()
++        self.localtime.symlink_to(self.zoneinfo / "Europe/Berlin")
++        self.vconsole.write_text("KEYMAP=us\nXKBLAYOUT=fr\n")
++        self.apply("tryomarchy.tz=America/New_York tryomarchy.kb=de")
++        self.assertEqual(os.readlink(self.localtime), str(self.zoneinfo / "Europe/Berlin"))
++        self.assertEqual(self.vconsole.read_text(), "KEYMAP=us\nXKBLAYOUT=fr\n")
++        self.apply("tryomarchy.tz=Europe/Berlin tryomarchy.kb=us:intl")
++        self.assertEqual(os.readlink(self.localtime), str(self.zoneinfo / "Europe/Berlin"))
++        self.assertEqual(self.vconsole.read_text(), "KEYMAP=us\nXKBLAYOUT=us\nXKBVARIANT=intl\n")
++
++    def test_rejects_unsafe_values_and_missing_zones(self) -> None:
++        result = self.apply("tryomarchy.tz=../../etc/passwd tryomarchy.kb=us;id")
++        self.assertEqual(result.returncode, 0, result.stderr)
++        self.assertIn("invalid", result.stderr)
++        self.assertEqual(os.readlink(self.localtime), str(self.zoneinfo / "UTC"))
++        self.assertEqual(self.vconsole.read_text(), "KEYMAP=us\n")
++        result = self.apply("tryomarchy.tz=Mars/Olympus")
++        self.assertEqual(result.returncode, 0)
++        self.assertIn("not installed", result.stderr)
++        self.assertEqual(os.readlink(self.localtime), str(self.zoneinfo / "UTC"))
++
++    def test_no_parameters_change_nothing(self) -> None:
++        result = self.apply("root=/dev/vda quiet")
++        self.assertEqual(result.returncode, 0, result.stderr)
++        self.assertEqual(self.vconsole.read_text(), "KEYMAP=us\n")
++        self.assertFalse((self.state / "host-timezone").exists())
+diff --git a/guest/tests/verify.py b/guest/tests/verify.py
+index dbf1fa0..979a092 100755
+--- a/guest/tests/verify.py
++++ b/guest/tests/verify.py
+@@ -257,8 +257,10 @@ def main() -> None:
+ 
+     finalize_rootfs = read(GUEST / "scripts/finalize-rootfs.sh")
+     check(
+-        "compat_revision=5" in finalize_rootfs
++        "compat_revision=6" in finalize_rootfs
+         and "compat_revision" in finalize_rootfs.split("compat-version")[0]
++        and "usr/local/lib/try-omarchy/apply-host-locale" in finalize_rootfs
++        and "etc/systemd/system/sysinit.target.wants/try-omarchy-host-locale.service" in finalize_rootfs
+         and "usr/local/bin/clipboard-bridge" in finalize_rootfs
+         and "etc/systemd/user/graphical-session.target.wants/clipboard-bridge.service" in finalize_rootfs,
+         "launcher integration has an explicit revision for persistent-disk upgrades",
+-- 
+2.55.0
+

--- a/guest-build/README.md
+++ b/guest-build/README.md
@@ -54,6 +54,10 @@ Windows VM tests unless noted in the release checklist):
   directory under its own name at login, pins it in the Files sidebar, and
   opens each newly selected share once so users can find it immediately; it
   removes only those managed entries on launches that share nothing
+- `tryomarchy.tz=` and `tryomarchy.kb=` (set by the launcher from the Windows
+  time zone and default input language) are applied at boot by a sysinit
+  service when they change, so the guest clock and Hyprland's keyboard layout
+  follow Windows without overriding a choice made inside the guest
 - New users start with no Hyprland toggles switched on. The builder used to
   copy every toggle template into the user's toggle state, which turned "no
   gaps" and "single-window aspect ratio" on permanently and overrode the gaps,

--- a/scripts/release/smoke-guest.py
+++ b/scripts/release/smoke-guest.py
@@ -27,7 +27,7 @@ FACT_CHECKS = {
     "sshd": "systemctl is-active sshd 2>/dev/null || true",
     "omarchy-repo-signed": "grep -A2 '^\\[omarchy\\]' /etc/pacman.conf | grep -q TrustAll && echo no || echo yes",
     "input-group": "id -nG | tr ' ' '\\n' | grep -qx input && echo yes || echo no",
-    "compat-version": "test \"$(cat /usr/share/try-omarchy/compat-version)\" = \"5:$(uname -r)\" && echo yes || echo no",
+    "compat-version": "test \"$(cat /usr/share/try-omarchy/compat-version)\" = \"6:$(uname -r)\" && echo yes || echo no",
     "kernel-modules": "test -f /usr/lib/modules/$(uname -r)/modules.dep.bin && echo yes || echo no",
     "ready-service": "systemctl is-enabled try-omarchy-ready.service 2>/dev/null || true",
 }


### PR DESCRIPTION
The guest booted in UTC with a US keyboard no matter what Windows used, which is the first thing a non-US user hits.

Launcher: `locale.go` carries the CLDR Windows-to-IANA zone table (139 entries, territory 001) and a KLID-to-XKB table with full identifiers for US-International, Dvorak and friends ahead of the per-language fallback. The launcher reads the time zone key name from HKLM and the user's default input language from the Preload list, and adds `tryomarchy.tz=` and `tryomarchy.kb=layout[:variant]` to the kernel command line, logging what it sent. Values are validated on both sides. `-timezone` and `-keyboard` override this per launch (`keep` leaves the guest alone). Diagnostics record both host values.

Guest (patch 0034): `try-omarchy-host-locale.service` runs at sysinit before the display manager and applies each value only when it differs from the one applied last, recorded under `/var/lib/try-omarchy`, so a zone or layout chosen inside the guest survives until Windows changes. The zone becomes the `/etc/localtime` link; the layout goes into `/etc/vconsole.conf` as `XKBLAYOUT`/`XKBVARIANT`, which Omarchy's Hyprland input config already reads (non-Latin layouts get its `us,` prefix handling for free). Unknown zones and unsafe values are ignored with a log line. Four overlay tests cover apply, persistence of guest changes, unsafe values, and no parameters. The service ships in the compat overlay so existing disks gain it; the integration revision and the release smoke test expectation move to 6.

Tested in the Win11 VM (Eastern Standard Time, KLID 00000409): the launcher logged `tryomarchy.tz=America/New_York tryomarchy.kb=us` and the QEMU command line carried both. Inside the running v0.0.12 guest, the new script run by hand with a fake command line switched `date +%Z` to CEST and `hyprctl getoption input:kb_layout` to `de` after a reload, then back to UTC and `us`. The boot-time path needs the next prepared guest image; `build-guest.sh --contract-only` passes with the patch applied.