### PR TITLE
Add the Windows VM test harness to scripts/vmtest

### DIFF
--- a/scripts/vmtest/README.md
+++ b/scripts/vmtest/README.md
@@ -1,0 +1,85 @@
+# Windows VM test harness
+
+These scripts drive a candidate launcher inside a Windows 11 VM without anyone
+at the keyboard. They are what the v0.0.12 release checklist and the follow-up
+launcher work were verified with. Nothing here runs in CI yet; it needs a host
+with nested virtualization and a Windows guest.
+
+## The VM
+
+A [dockur/windows](https://github.com/dockur/windows) container with `VMX=Y`
+and a Windows 11 guest. Windows 10 cannot run nested WHPX and hangs at boot
+once the Hypervisor Platform is enabled, so use Windows 11. Give the container
+8 GB and 4 cores; the launcher sizes the guest from what Windows can spare.
+Expose the guest's OpenSSH server on a loopback port (2222 below) and mount a
+host folder as `\\host.lan\Data` so files and screenshots move both ways.
+
+GPU rendering never works under nested virtualization. Every launch falls back
+to CPU rendering, and the launcher remembers that in `render-probe.json`.
+Anything GPU, audio, sleep, DPI, or remote-session related needs physical
+hardware; see `docs/RUNTIME-VALIDATION.md`.
+
+## Serving the release payload
+
+The launcher downloads without a GitHub token and a draft release's assets
+require one, so serve the assets from the container instead:
+
+```bash
+docker exec -d omarchy-windows sh -c 'python3 -m http.server 18080 --bind 0.0.0.0 --directory /shared/candidate > /tmp/http.log 2>&1'
+```
+
+Inside the VM the container host is `172.30.0.1`, so the launcher takes
+`-release http://172.30.0.1:18080/assets -sums-sha256 <digest>` and the
+matching `-runtime-*` flags. `/tmp/http.log` in the container shows exactly
+which assets each launch fetched, which is how the "no re-download" checks
+are made.
+
+## Running PowerShell in the VM
+
+`winps.sh` runs a PowerShell script (file or stdin) over SSH without echoing
+the password; it reads `PASSWORD` from the container's environment. Two traps:
+
+- Multi-line `if`/`while` blocks over `powershell -Command -` stop silently.
+  Keep control flow on one line, or end the script with a blank line.
+- Every SSH PowerShell session opens a Windows Terminal window on the VM
+  desktop that covers dialogs. Screenshots must minimize other windows and
+  raise the target from inside the interactive task (`screenshot.ps1 -front`).
+
+Anything that opens a window (the launcher, Settings, dialogs) must run as an
+interactive scheduled task, not from the SSH session. `run-candidate.ps1` does
+that for a launcher build and waits for the guest to report ready.
+
+## Driving the guest
+
+`qmp.ps1` talks to QEMU's tools QMP port (4445) from inside the VM:
+`qmp.ps1 key meta_l,ret` opens a terminal in Omarchy, `qmp.ps1 type '...'`
+and `qmp.ps1 key ret` run a command. Pair it with the shared folder: put a
+script in `Omarchy Shared`, run it with `bash ~/Omarchy\ Shared/x.sh`, and
+have it write its results back to the same folder. Nested SSH into the guest
+stalls; keystrokes and the shared folder do not.
+
+Never send keystrokes with `sendkeys.ps1` to the "Try Omarchy" title while
+the VM window is up: they land inside the guest.
+
+## Other helpers
+
+- `sendkeys.ps1 -title T -keys K` answers a launcher prompt (Enter selects
+  the highlighted option).
+- `screenshot.ps1 -out file.png [-front "window title"]` captures the desktop.
+- `movewin.ps1 -out file.txt [-read]` moves the VM window or reports its
+  rectangle, for the window-placement checks.
+- `clipimg.ps1 -out file.txt -set | -get | -text "..."` puts an image or text
+  on the Windows clipboard, or reports what it holds.
+- `sparsetool/` is a small Windows program (`go build` with `GOOS=windows`)
+  that extracts a backup ZIP, copies a data folder, or hashes a tree while
+  keeping sparse files sparse. The launcher's own restore budgets space from
+  the compressed size, but this is still the fastest way to stage a copied
+  install for a test.
+
+## Checks worth repeating on every candidate
+
+Backup and restore, in-place update with the compat repair, in-guest reboot
+and poweroff, a second launch that downloads only `SHA256SUMS`, disk growth,
+a fresh install through the location picker, and the forced rollback (kill
+the launcher after "QMP connected" and before "userspace announced ready",
+then relaunch and confirm no download and the previous payload).

--- a/scripts/vmtest/clipimg.ps1
+++ b/scripts/vmtest/clipimg.ps1
@@ -1,0 +1,7 @@
+param([string]$out, [switch]$set, [switch]$get, [string]$text = "")
+Add-Type -AssemblyName System.Windows.Forms; Add-Type -AssemblyName System.Drawing
+if ($set) { $bmp = New-Object System.Drawing.Bitmap 123, 45; $g = [System.Drawing.Graphics]::FromImage($bmp); $g.Clear([System.Drawing.Color]::FromArgb(255, 200, 30, 90)); $g.Dispose(); [System.Windows.Forms.Clipboard]::SetImage($bmp); "set image 123x45" | Set-Content $out; exit }
+if ($text -ne "") { [System.Windows.Forms.Clipboard]::SetText($text); "set text" | Set-Content $out; exit }
+$has = [System.Windows.Forms.Clipboard]::ContainsImage(); $line = "containsImage=$has containsText=$([System.Windows.Forms.Clipboard]::ContainsText())"
+if ($has) { $img = [System.Windows.Forms.Clipboard]::GetImage(); $line += " size=$($img.Width)x$($img.Height) pixel=$($img.GetPixel(0,0))" }
+$line | Set-Content $out

--- a/scripts/vmtest/movewin.ps1
+++ b/scripts/vmtest/movewin.ps1
@@ -1,0 +1,17 @@
+param([string]$out, [int]$x = 100, [int]$y = 80, [int]$w = 1000, [int]$h = 700, [switch]$read)
+Add-Type @"
+using System; using System.Runtime.InteropServices; using System.Text;
+public class W {
+  [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int cmd);
+  [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr h, int x, int y, int w, int hh, bool repaint);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool IsZoomed(IntPtr h);
+  [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L, T, R, B; }
+}
+"@
+$q = Get-Process qemu-system-x86_64w -ErrorAction SilentlyContinue | Where-Object { $_.MainWindowHandle -ne 0 } | Select-Object -First 1
+if (-not $q) { "no qemu window" | Set-Content $out; exit }
+$hwnd = $q.MainWindowHandle
+if (-not $read) { [W]::ShowWindow($hwnd, 9) | Out-Null; Start-Sleep -Milliseconds 500; [W]::MoveWindow($hwnd, $x, $y, $w, $h, $true) | Out-Null; Start-Sleep -Milliseconds 500 }
+$r = New-Object W+RECT; [W]::GetWindowRect($hwnd, [ref]$r) | Out-Null
+"rect=$($r.L),$($r.T),$($r.R),$($r.B) zoomed=$([W]::IsZoomed($hwnd)) title=$($q.MainWindowTitle)" | Set-Content $out

--- a/scripts/vmtest/qmp.ps1
+++ b/scripts/vmtest/qmp.ps1
@@ -1,0 +1,84 @@
+# QMP driver for the running Omarchy guest (port 4445).
+# Usage: qmp.ps1 shot NAME | type STRING | key NAME[,NAME...] | status
+param([Parameter(Mandatory)][string]$op, [string]$arg = '')
+$ErrorActionPreference = 'Stop'
+
+$tcp = New-Object Net.Sockets.TcpClient('127.0.0.1', 4445)
+$s = $tcp.GetStream(); $s.ReadTimeout = 5000
+$w = New-Object IO.StreamWriter($s); $w.AutoFlush = $true
+$r = New-Object IO.StreamReader($s)
+$r.ReadLine() | Out-Null
+$w.WriteLine('{"execute":"qmp_capabilities"}'); Start-Sleep -Milliseconds 400
+try { $r.ReadLine() | Out-Null } catch {}
+
+function Send-Keys([string[]]$qcodes) {
+    $keys = ($qcodes | ForEach-Object { "{`"type`":`"qcode`",`"data`":`"$_`"}" }) -join ','
+    $w.WriteLine("{`"execute`":`"send-key`",`"arguments`":{`"keys`":[$keys]}}")
+    Start-Sleep -Milliseconds 120
+    try { $r.ReadLine() | Out-Null } catch {}
+}
+
+switch ($op) {
+    'shot' {
+        $w.WriteLine("{`"execute`":`"screendump`",`"arguments`":{`"filename`":`"$($arg -replace '\\','\\\\')`"}}")
+        Start-Sleep -Milliseconds 1500
+        try { Write-Host $r.ReadLine() } catch {}
+        Write-Host "shot $arg"
+    }
+    'type' {
+        foreach ($ch in $arg.ToCharArray()) {
+            $c = [string]$ch
+            if ($c -cmatch '^[a-z0-9]$') { Send-Keys @($c) }
+            elseif ($c -cmatch '^[A-Z]$') { Send-Keys @('shift', $c.ToLower()) }
+            else {
+                switch ($c) {
+                    '-' { Send-Keys @('minus') }
+                    '.' { Send-Keys @('dot') }
+                    ' ' { Send-Keys @('spc') }
+                    '_' { Send-Keys @('shift','minus') }
+                    '@' { Send-Keys @('shift','2') }
+                    '/' { Send-Keys @('slash') }
+                    '\' { Send-Keys @('backslash') }
+                    '|' { Send-Keys @('shift','backslash') }
+                    ':' { Send-Keys @('shift','semicolon') }
+                    ';' { Send-Keys @('semicolon') }
+                    ',' { Send-Keys @('comma') }
+                    '=' { Send-Keys @('equal') }
+                    '*' { Send-Keys @('shift','8') }
+                    '$' { Send-Keys @('shift','4') }
+                    '(' { Send-Keys @('shift','9') }
+                    ')' { Send-Keys @('shift','0') }
+                    '>' { Send-Keys @('shift','dot') }
+                    '<' { Send-Keys @('shift','comma') }
+                    "'" { Send-Keys @('apostrophe') }
+                    '"' { Send-Keys @('shift','apostrophe') }
+                    '{' { Send-Keys @('shift','bracket_left') }
+                    '}' { Send-Keys @('shift','bracket_right') }
+                    '[' { Send-Keys @('bracket_left') }
+                    ']' { Send-Keys @('bracket_right') }
+                    '!' { Send-Keys @('shift','1') }
+                    '#' { Send-Keys @('shift','3') }
+                    '%' { Send-Keys @('shift','5') }
+                    '^' { Send-Keys @('shift','6') }
+                    '&' { Send-Keys @('shift','7') }
+                    '+' { Send-Keys @('shift','equal') }
+                    '?' { Send-Keys @('shift','slash') }
+                    '`' { Send-Keys @('grave_accent') }
+                    '~' { Send-Keys @('shift','grave_accent') }
+                    default { throw "unmapped char: $c" }
+                }
+            }
+        }
+        Write-Host "typed"
+    }
+    'key' {
+        foreach ($k in $arg -split '/') { Send-Keys ($k -split ',') }
+        Write-Host "keyed"
+    }
+    'status' {
+        $w.WriteLine('{"execute":"query-status"}'); Start-Sleep -Milliseconds 500
+        Write-Host $r.ReadLine()
+    }
+    default { throw "unknown op: $op" }
+}
+$tcp.Close()

--- a/scripts/vmtest/run-candidate.ps1
+++ b/scripts/vmtest/run-candidate.ps1
@@ -1,0 +1,37 @@
+# Runs a launcher build inside the Windows test VM as an interactive scheduled
+# task and waits for the guest to report ready. Run it inside the VM through
+# winps.sh. Interactive tasks are the only way a session started over SSH can
+# open windows on the console desktop.
+#
+#   run-candidate.ps1 -Exe C:\path\TryOmarchy.exe -Dir C:\Users\me\AppData\Local\TryOmarchy `
+#       -Release http://172.30.0.1:18080/assets -Sums <sha256 of SHA256SUMS> [-ExtraArgs '-ssh 2223']
+param(
+  [Parameter(Mandatory)][string]$Exe,
+  [Parameter(Mandatory)][string]$Dir,
+  [string]$Release = '',
+  [string]$Sums = '',
+  [string]$ExtraArgs = '',
+  [int]$TimeoutSeconds = 300,
+  [string]$TaskName = 'TryOmarchyCandidateRun'
+)
+$launchArgs = "-dir `"$Dir`" -no-update $ExtraArgs"
+if ($Release -ne '') { $launchArgs += " -release $Release -sums-sha256 $Sums -runtime-release $Release -runtime-sums-sha256 $Sums" }
+$runner = Join-Path $env:TEMP "$TaskName.cmd"
+$exitFile = Join-Path $env:TEMP "$TaskName.exit.txt"
+Set-Content -Encoding ascii $runner "@echo off`r`n`"$Exe`" $launchArgs > `"$exitFile`" 2>&1`r`necho exit %ERRORLEVEL% >> `"$exitFile`""
+Remove-Item $exitFile -ErrorAction SilentlyContinue
+Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+$action = New-ScheduledTaskAction -Execute 'cmd.exe' -Argument "/c `"$runner`""
+$principal = New-ScheduledTaskPrincipal -UserId "$env:COMPUTERNAME\$env:USERNAME" -LogonType Interactive -RunLevel Limited
+$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 6)
+Register-ScheduledTask -TaskName $TaskName -Action $action -Principal $principal -Settings $settings | Out-Null
+$log = Join-Path $Dir 'vm\shell.log'
+$before = 0; if (Test-Path $log) { $before = (Get-Content $log).Count }
+Start-ScheduledTask -TaskName $TaskName
+$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+while ((Get-Date) -lt $deadline) {
+  if (Test-Path $log) { $all = Get-Content $log; if ($all.Count -gt $before -and ($all[$before..($all.Count-1)] -match 'userspace announced ready|---- exiting|FATAL')) { break } }
+  Start-Sleep 5
+}
+if (Test-Path $log) { $all = Get-Content $log; if ($all.Count -gt $before) { $all[$before..($all.Count-1)] } }
+Get-Content $exitFile -ErrorAction SilentlyContinue

--- a/scripts/vmtest/screenshot.ps1
+++ b/scripts/vmtest/screenshot.ps1
@@ -1,0 +1,10 @@
+param([string]$out, [string]$front = "")
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+Add-Type -AssemblyName Microsoft.VisualBasic
+if ($front -ne "") { (New-Object -ComObject Shell.Application).MinimizeAll(); Start-Sleep -Milliseconds 700; [Microsoft.VisualBasic.Interaction]::AppActivate($front) | Out-Null; Start-Sleep -Milliseconds 700 }
+$b = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+$bmp = New-Object System.Drawing.Bitmap $b.Width, $b.Height
+$g = [System.Drawing.Graphics]::FromImage($bmp)
+$g.CopyFromScreen($b.Location, [System.Drawing.Point]::Empty, $b.Size)
+$bmp.Save($out, [System.Drawing.Imaging.ImageFormat]::Png)

--- a/scripts/vmtest/sendkeys.ps1
+++ b/scripts/vmtest/sendkeys.ps1
@@ -1,0 +1,6 @@
+param([string]$title, [string]$keys)
+Add-Type -AssemblyName Microsoft.VisualBasic
+Add-Type -AssemblyName System.Windows.Forms
+[Microsoft.VisualBasic.Interaction]::AppActivate($title) | Out-Null
+Start-Sleep -Milliseconds 400
+[System.Windows.Forms.SendKeys]::SendWait($keys)

--- a/scripts/vmtest/sparsetool/go.mod
+++ b/scripts/vmtest/sparsetool/go.mod
@@ -1,0 +1,3 @@
+module sparsetool
+
+go 1.27

--- a/scripts/vmtest/sparsetool/main.go
+++ b/scripts/vmtest/sparsetool/main.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+const fsctlSetSparse = 0x000900C4
+
+var (
+	kernel32            = syscall.NewLazyDLL("kernel32.dll")
+	procDeviceIoControl = kernel32.NewProc("DeviceIoControl")
+)
+
+func setSparse(f *os.File) error {
+	var returned uint32
+	r, _, err := procDeviceIoControl.Call(f.Fd(), fsctlSetSparse, 0, 0, 0, 0, uintptr(unsafe.Pointer(&returned)), 0)
+	if r == 0 {
+		return err
+	}
+	return nil
+}
+
+// sparseWrite copies r into a new sparse file at target, skipping all-zero
+// 1 MiB blocks, and returns the size and sha256 written.
+func sparseWrite(target string, r io.Reader) (int64, string, error) {
+	if err := os.MkdirAll(filepath.Dir(target), 0700); err != nil {
+		return 0, "", err
+	}
+	f, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return 0, "", err
+	}
+	defer f.Close()
+	if err := setSparse(f); err != nil {
+		return 0, "", fmt.Errorf("set sparse: %w", err)
+	}
+	buf := make([]byte, 1<<20)
+	zero := make([]byte, 1<<20)
+	h := sha256.New()
+	var off int64
+	for {
+		n, rerr := io.ReadFull(r, buf)
+		if n > 0 {
+			h.Write(buf[:n])
+			if bytes.Equal(buf[:n], zero[:n]) {
+				off += int64(n)
+				if _, err := f.Seek(off, io.SeekStart); err != nil {
+					return 0, "", err
+				}
+			} else {
+				if _, err := f.Write(buf[:n]); err != nil {
+					return 0, "", err
+				}
+				off += int64(n)
+			}
+		}
+		if rerr == io.EOF || rerr == io.ErrUnexpectedEOF {
+			break
+		}
+		if rerr != nil {
+			return 0, "", rerr
+		}
+	}
+	if err := f.Truncate(off); err != nil {
+		return 0, "", err
+	}
+	return off, hex.EncodeToString(h.Sum(nil)), nil
+}
+
+type manifest struct {
+	Version int `json:"version"`
+	Files   []struct {
+		Name   string `json:"name"`
+		Size   int64  `json:"size"`
+		SHA256 string `json:"sha256"`
+	} `json:"files"`
+}
+
+func extract(zipPath, dest string) error {
+	if _, err := os.Lstat(dest); err == nil {
+		return fmt.Errorf("destination exists")
+	}
+	z, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+	defer z.Close()
+	files := map[string]*zip.File{}
+	for _, f := range z.File {
+		files[f.Name] = f
+	}
+	mf := files["backup.json"]
+	if mf == nil {
+		return fmt.Errorf("no backup.json")
+	}
+	mr, err := mf.Open()
+	if err != nil {
+		return err
+	}
+	var m manifest
+	if err := json.NewDecoder(mr).Decode(&m); err != nil {
+		return err
+	}
+	mr.Close()
+	for _, e := range m.Files {
+		zf := files[e.Name]
+		if zf == nil {
+			return fmt.Errorf("missing %s", e.Name)
+		}
+		r, err := zf.Open()
+		if err != nil {
+			return err
+		}
+		n, sum, err := sparseWrite(filepath.Join(dest, filepath.FromSlash(e.Name)), r)
+		r.Close()
+		if err != nil {
+			return fmt.Errorf("%s: %w", e.Name, err)
+		}
+		if n != e.Size || sum != e.SHA256 {
+			return fmt.Errorf("%s: size/hash mismatch", e.Name)
+		}
+		fmt.Printf("ok %s %d\n", e.Name, n)
+	}
+	return nil
+}
+
+func copyTree(src, dst string) error {
+	if _, err := os.Lstat(dst); err == nil {
+		return fmt.Errorf("destination exists")
+	}
+	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, p)
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0700)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("%s: not a regular file", p)
+		}
+		in, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+		n, _, err := sparseWrite(target, in)
+		if err != nil {
+			return fmt.Errorf("%s: %w", rel, err)
+		}
+		if n != info.Size() {
+			return fmt.Errorf("%s: short copy", rel)
+		}
+		fmt.Printf("ok %s %d\n", rel, n)
+		return nil
+	})
+}
+
+func hashTree(root string) error {
+	var names []string
+	err := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			names = append(names, p)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	sort.Strings(names)
+	for _, p := range names {
+		f, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		h := sha256.New()
+		n, err := io.Copy(h, f)
+		f.Close()
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(root, p)
+		fmt.Printf("%s %d %s\n", hex.EncodeToString(h.Sum(nil)), n, strings.ReplaceAll(rel, "\\", "/"))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "usage: sparsetool extract ZIP DEST | copy SRC DST | hash DIR")
+		os.Exit(2)
+	}
+	var err error
+	switch os.Args[1] {
+	case "extract":
+		err = extract(os.Args[2], os.Args[3])
+	case "copy":
+		err = copyTree(os.Args[2], os.Args[3])
+	case "hash":
+		err = hashTree(os.Args[2])
+	default:
+		err = fmt.Errorf("unknown command")
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+	fmt.Println("done")
+}

--- a/scripts/vmtest/winps.sh
+++ b/scripts/vmtest/winps.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Run a PowerShell script (file arg or stdin) inside the Win11 VM over SSH. Never echoes the password.
+set -euo pipefail
+export SSHPASS="$(docker inspect omarchy-windows --format '{{range .Config.Env}}{{println .}}{{end}}' | sed -n 's/^PASSWORD=//p')"
+src="${1:-/dev/stdin}"
+sshpass -e ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o LogLevel=ERROR -p 2222 bts@127.0.0.1 'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command -' < "$src" 2>&1 | grep -v "post-quantum\|openssh.com/pq\|^\*\* "


### PR DESCRIPTION
The PowerShell and shell helpers that drove every candidate check in the Windows 11 VM this week lived in a scratch folder. This puts them in the repo under `scripts/vmtest` with a README that records the setup and the traps: the dockur container (Windows 11 only, nested WHPX never gives GPU), the loopback asset server for draft releases, the scheduled-task pattern for anything that opens a window, the QMP keystroke route into the guest through the shared folder, and the PowerShell-over-SSH quirks that silently swallow multi-line blocks and cover dialogs with a terminal window.

`run-candidate.ps1` is a generic runner that starts a launcher build as an interactive task with the local payload flags and waits for the guest to report ready. `sparsetool` is the sparse-aware extract, copy, and hash tool used to stage copied installs. Nothing runs in CI; this is documentation plus scripts for a self-hosted runner later.