### PR TITLE
Automate the guest package lock refresh

### DIFF
--- a/.github/workflows/refresh-guest-lock.yml
+++ b/.github/workflows/refresh-guest-lock.yml
@@ -1,0 +1,61 @@
+name: Refresh guest lock
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: refresh-guest-lock
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Refresh the guest package lock
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out source
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Refresh the lock
+        id: refresh
+        run: |
+          set -o pipefail
+          scripts/release/refresh-guest-lock.sh | tee refresh.log
+          if git status --porcelain guest-build | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open a pull request
+        if: steps.refresh.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          patch=$(git status --porcelain guest-build | awk '{print $2}' | head -1)
+          branch="guest-lock/$(date -u +%Y-%m-%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add guest-build
+          git commit -m "Refresh the guest package lock"
+          git push origin "$branch"
+          {
+            echo "Arch moved since the guest package lock was written. This adds \`$patch\` so the next prepared guest image builds from the current packages instead of refusing on lock drift."
+            echo
+            echo "Package changes:"
+            echo
+            echo '```'
+            sed -n '/^wrote guest-build/,$p' refresh.log | tail -n +2
+            echo '```'
+            echo
+            echo "The guest contract tests passed with the patch applied. CI does not run automatically on a pull request opened with the workflow token; close and reopen it, or push an empty commit, to trigger the checks before merging."
+          } > body.md
+          gh pr create --title "Refresh the guest package lock" --body-file body.md --head "$branch" --base master

--- a/guest-build/README.md
+++ b/guest-build/README.md
@@ -69,8 +69,13 @@ Windows VM tests unless noted in the release checklist):
   launcher commits a guest-image update. Its explicit integration revision is
   bumped whenever those files must be reapplied without a kernel version change
 
-If Arch has moved since the lock was written, refresh it first and review the diff:
+If Arch has moved since the lock was written, refresh it first and review the diff.
+`scripts/release/refresh-guest-lock.sh` does the whole dance: it checks out the
+locked source, applies the patches, resolves the lock in Docker, and writes the
+next numbered `Refresh-the-guest-package-lock` patch here when anything changed.
+The `Refresh guest lock` workflow runs it every Monday and opens a pull request
+with the package changes; `--check` reports drift without writing a patch.
 
 ```bash
-sudo bash guest/build-container.sh --refresh-package-lock guest/packages.lock.json
+scripts/release/refresh-guest-lock.sh
 ```

--- a/scripts/release/refresh-guest-lock.sh
+++ b/scripts/release/refresh-guest-lock.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Refreshes the guest package lock against current Arch and, when it moved,
+# writes the next numbered patch under guest-build/. Run it locally (needs
+# Docker and sudo, like the guest build) or let the scheduled workflow do it.
+#
+#   scripts/release/refresh-guest-lock.sh            # writes guest-build/NNNN-Refresh-the-guest-package-lock.patch
+#   scripts/release/refresh-guest-lock.sh --check    # exit 3 when the lock drifted, 0 when current
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/../.." && pwd)
+check_only=0
+[[ ${1:-} == --check ]] && check_only=1
+
+readarray -t source_fields < <(python3 - "$repo_root/guest-build/source.lock.json" <<'PY'
+import json, pathlib, sys
+lock = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(lock["repository"]); print(lock["commit"])
+PY
+)
+source_url=${source_fields[0]}
+source_commit=${source_fields[1]}
+
+work=$(mktemp -d "${RUNNER_TEMP:-/tmp}/try-omarchy-lock-refresh.XXXXXX")
+trap 'rm -rf -- "$work"' EXIT
+git -C "$work" init --quiet
+git -C "$work" remote add origin "$source_url"
+git -C "$work" fetch --quiet --depth=1 origin "$source_commit"
+git -C "$work" checkout --quiet --detach FETCH_HEAD
+git -C "$work" config user.name "Try Omarchy Release"
+git -C "$work" config user.email "actions@users.noreply.github.com"
+git -C "$work" am --quiet "$repo_root"/guest-build/*.patch
+
+sudo bash "$work/guest/build-container.sh" --refresh-package-lock "$work/guest/packages.lock.json"
+sudo chown -- "$(id -u):$(id -g)" "$work/guest/packages.lock.json"
+
+if git -C "$work" diff --quiet -- guest/packages.lock.json; then
+  echo "guest package lock is current"
+  exit 0
+fi
+if ((check_only)); then
+  echo "guest package lock drifted:"
+  git -C "$work" --no-pager diff --stat -- guest/packages.lock.json
+  exit 3
+fi
+
+summary=$(python3 - "$work/guest/packages.lock.json" <<'PY'
+import json, pathlib, subprocess, sys
+path = pathlib.Path(sys.argv[1])
+new = json.loads(path.read_text())["packages"]
+old = json.loads(subprocess.check_output(["git", "-C", str(path.parents[1]), "show", "HEAD:guest/packages.lock.json"]))["packages"]
+changed = [f"{name} {old[name]} -> {new[name]}" for name in sorted(new) if name in old and old[name] != new[name]]
+added = [f"{name} {new[name]} (new)" for name in sorted(new) if name not in old]
+removed = [f"{name} (removed)" for name in sorted(old) if name not in new]
+print("\n".join(changed + added + removed))
+PY
+)
+git -C "$work" add guest/packages.lock.json
+git -C "$work" commit --quiet -m "Refresh the guest package lock" -m "$summary"
+last=$(ls "$repo_root"/guest-build/*.patch | sed 's/.*\/\([0-9]*\)-.*/\1/' | sort -n | tail -1)
+next=$(printf '%04d' $((10#$last + 1)))
+git -C "$work" format-patch --quiet -1 --start-number "$((10#$next))" -o "$repo_root/guest-build/"
+"$work/guest/test"
+echo "wrote guest-build/$next-Refresh-the-guest-package-lock.patch"
+printf '%s\n' "$summary"


### PR DESCRIPTION
Every release so far started with the prepare phase refusing on lock drift, followed by a manual refresh done from notes. This makes the refresh a script and a schedule.

`scripts/release/refresh-guest-lock.sh` checks out the guest source at `source.lock.json`, applies every patch, runs the builder's `--refresh-package-lock` in Docker, and when the lock changed commits it in the work tree, writes the next numbered `Refresh-the-guest-package-lock` patch into `guest-build/`, and runs the guest contract tests. `--check` only reports drift (exit 3). The patch body lists the package version changes.

The `Refresh guest lock` workflow runs the script every Monday (and on dispatch) and opens a pull request on a dated branch with those changes in the body. It uses the workflow token, so CI does not start on the PR by itself; the body says to close and reopen it or push an empty commit. A repository PAT would remove that step later.

I could not run the Docker part locally (it needs sudo), so the script is syntax-checked and follows the same sequence `build-guest.sh` already uses; the first scheduled run is the real test. The guest-build README points at it.