### PR TITLE
Extend the tester checklist and name the Windows host in the guest

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ ssh -p 2222 <omarchy-user>@127.0.0.1
 The same alias works for `scp`, Git, and VS Code Remote SSH. Other services
 use `-forward tcp:8080:80` or `-forward udp:5000:5000` (repeatable); the guest
 service must listen on its network interface, not only on its own localhost.
-From Omarchy, `10.0.2.2:<port>` reaches a service on Windows without any
+From Omarchy, `windows.host:<port>` (10.0.2.2) reaches a service on Windows without any
 mapping. Key-only or permanent SSH is Omarchy's own choice: run
 `omarchy-setup-security-sshd` inside the guest. A fresh disk (`-fresh`) gets a
 new host key, so remove the old `[127.0.0.1]:2222` entry from `known_hosts`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -49,6 +49,36 @@ personal details. Do not upload the guest disk or a full backup.
 - [ ] At least one hour of use without the launcher exiting or input forwarding
   stopping. Report idle CPU after five minutes without animation.
 - [ ] RDP and VNC sessions, including Ctrl+Alt+G as the input fallback.
+- [ ] Image clipboard: a Windows screenshot pastes into an Omarchy app, and an
+  image copied in Omarchy pastes into a Windows app. Text keeps working after.
+- [ ] The guest clock matches Windows after a sleep and resume, and the desktop
+  keyboard layout and time zone match the Windows ones on a non-US machine,
+  including AltGr and dead keys.
+- [ ] Close the VM window at a moved, non-maximized size; the next launch opens
+  it there. Unplug the monitor it was on; the next launch opens maximized.
+- [ ] Reclaim disk space from the tray after deleting a large file in Omarchy;
+  after shutdown the disk file is smaller and Windows free space never fell
+  below 4 GiB during the pass. Repeat with Settings showing the new size.
+- [ ] Settings: Rendering set to CPU and back to Automatic takes effect on the
+  next launch; Guest CPUs shows the automatic choice for this PC.
+- [ ] Remove Try Omarchy from Apps & features on a copied install; the folder,
+  its shortcuts, and its entry are gone and the original install still runs.
+
+## Hardware matrix facts to record
+
+The nested test VM cannot answer these; every physical report should.
+
+- GPU vendor, driver version, and whether the desktop came up on GPU or CPU
+  rendering (`render-probe.json` in the data folder records the result).
+- Idle CPU of `qemu-system-x86_64w.exe` in Task Manager five minutes after the
+  desktop settles, with and without a video playing.
+- Whether the Windows microphone indicator lights at launch before any app
+  records, and whether it lights when one does.
+- Display scaling in use, and whether text in Omarchy is crisp at 125 percent
+  and above; whether moving the window between monitors with different
+  scaling leaves it usable.
+- Whether audio follows a headphone plug-in mid-session.
+- Whether the guest browses with the machine's VPN connected.
 
 ## Data and update recovery
 

--- a/guest-build/0038-Name-the-Windows-host-windows.host-inside-the-guest.patch
+++ b/guest-build/0038-Name-the-Windows-host-windows.host-inside-the-guest.patch
@@ -1,0 +1,26 @@
+From dd56e00386abf00831b7db0c00c0396908a727e3 Mon Sep 17 00:00:00 2001
+From: Tyler South <tsouth2@gmail.com>
+Date: Sat, 5 Sep 2026 07:41:17 -0400
+Subject: [PATCH] Name the Windows host windows.host inside the guest
+
+10.0.2.2 is the Windows side under QEMU user networking, where the launcher and any service the user runs on Windows are reachable. A hosts entry gives it a name people can type.
+---
+ guest/scripts/configure-rootfs.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/guest/scripts/configure-rootfs.sh b/guest/scripts/configure-rootfs.sh
+index 1081385..410c196 100755
+--- a/guest/scripts/configure-rootfs.sh
++++ b/guest/scripts/configure-rootfs.sh
+@@ -73,6 +73,8 @@ cat >"$root/etc/hosts" <<EOF
+ 127.0.0.1 localhost
+ ::1 localhost
+ 127.0.1.1 $hostname
++# The Windows host under QEMU user networking; the launcher listens there.
++10.0.2.2 windows.host
+ EOF
+ printf 'en_US.UTF-8 UTF-8\n' >"$root/etc/locale.gen"
+ printf 'LANG=en_US.UTF-8\n' >"$root/etc/locale.conf"
+-- 
+2.55.0
+


### PR DESCRIPTION
Two small things for the hardware work.

`docs/TESTING.md` gains checklist items for everything added since v0.0.12 (image clipboard, clock and keyboard following Windows, remembered window placement, disk reclaim, the Rendering and Guest CPUs settings, and uninstall from Apps & features), plus a short list of the facts every physical report has to record because the nested VM cannot produce them: GPU vendor and driver with the rendering outcome, idle CPU, microphone indicator behaviour, display scaling, audio device switching, and VPN.

Guest patch 0038 adds `10.0.2.2 windows.host` to the image's hosts file so people can reach a service on Windows by name from inside Omarchy; the README's port-forwarding section uses it. Only /etc/hosts in new images changes, so no compat revision bump.