### PR TITLE
Prepare v0.0.13-preview release notes

### DIFF
--- a/.github/release-notes/v0.0.13-preview.md
+++ b/.github/release-notes/v0.0.13-preview.md
@@ -1,0 +1,25 @@
+v0.0.13-preview follows v0.0.12-preview. It ships a rebuilt guest image (integration revision 9) and a launcher that adapts to the machine it runs on. Existing guest disks keep their data and gain the new guest services on the next launch.
+
+### New
+
+- Images cross the clipboard in both directions: a screenshot copied in Windows pastes into Omarchy, and an image copied in Omarchy pastes into Windows apps. Text keeps working as before.
+- The guest follows the Windows time zone and default keyboard layout, and a small guest agent keeps the Omarchy clock in step with Windows, including after sleep. A layout or zone chosen inside Omarchy stays until Windows changes.
+- Automatic rendering remembers when this PC cannot run the GPU path and goes straight to CPU rendering on later launches, retrying daily or after a runtime or driver change. A new Rendering setting (Automatic, GPU, CPU) overrides it. On CPU rendering the desktop starts with animations off.
+- Guest CPUs are sized to the machine (all logical processors but two, between two and eight) with a Guest CPUs setting and `-cpus`. CPU rendering also gets a larger automatic RAM ceiling; GPU rendering keeps its 6 GiB.
+- The VM window remembers its size and position between launches.
+- Try Omarchy registers under Windows Apps & features and can be removed from there, from **Remove Try Omarchy** in Settings, or with `-uninstall`, with a full backup offered first.
+- `TryOmarchy.exe -reclaim` gives the space of deleted Omarchy files back to Windows after the next shutdown, within a budget the Windows drive can spare.
+- `windows.host` names the Windows side inside Omarchy.
+
+### Fixed
+
+- A pending runtime update on a PC that runs on CPU rendering is kept and committed instead of being rolled back and downloaded again on every launch.
+- New guest users no longer start with the "no gaps" and "single-window aspect ratio" Hyprland toggles switched on, which silently overrode gaps, border size, and rounding set in `looknfeel.lua` (#32). Existing guests: run `omarchy-hyprland-window-gaps-toggle` once.
+- Restore budgets free space from the backup's compressed size instead of the sparse files' nominal size, keeps the recorded file times so a restored copy does not re-download its image and runtime, and no longer asks about shortcuts again.
+- Settings text under the SSH key row is no longer painted over, and messages logged before the session log opens now appear at the top of it.
+
+File drag and drop and file clipboard transfers are not included yet. Use `Omarchy Shared` for files.
+
+### Thanks
+
+Thanks to @solkkku for reporting the Hyprland config override that led to the toggle fix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.0.13-preview - 2026-09-05
 
 ### Features
 - Automatic rendering now remembers when this PC cannot run the GPU path and goes straight to CPU rendering on later launches, retrying after a runtime or display-driver change, once a day, or when GPU is chosen in the new Rendering setting. A pending runtime update on a PC that already runs on CPU rendering is kept instead of being rolled back and downloaded again on every launch.
@@ -17,6 +17,8 @@
 - Restore now budgets free space from the backup's compressed size instead of the sparse files' nominal size, so a 10 GB backup no longer demands 33 GB free. Restored files keep the modification times their receipts recorded, so a restored copy does not re-download its image and runtime on first launch, and a restore from Settings no longer asks about shortcuts again.
 - New guest users no longer start with the "no gaps" and "single-window aspect ratio" Hyprland toggles switched on, which silently overrode gaps, border size, and rounding set in `~/.config/hypr/looknfeel.lua` (#32). Existing guests keep their current toggles; run `omarchy-hyprland-window-gaps-toggle` once to turn gaps back on.
 - The Settings text under the SSH key row is no longer painted over by the label above it, and messages logged before the session log opens, such as the restored-payload decision after an interrupted update, now appear at the top of the log.
+
+Thanks to [solkkku](https://github.com/solkkku) for reporting the Hyprland config override (#32).
 
 ## v0.0.12-preview - 2026-09-05
 


### PR DESCRIPTION
Turns the Unreleased changelog section into v0.0.13-preview dated today, adds the release-notes file that becomes the GitHub release body, and thanks solkkku for the #32 report. The GPU-path wording matches the hardening in #68.