### PR TITLE
Give Print Screen to Omarchy while its window is focused

### DIFF
--- a/app/winapi.go
+++ b/app/winapi.go
@@ -53,6 +53,7 @@ const (
 	wmSyskeydown     = 0x104
 	vkLwin           = 0x5B
 	vkRwin           = 0x5C
+	vkSnapshot       = 0x2C
 	qsAllinput       = 0x04FF
 	pmRemove         = 1
 	cfUnicodetext    = 13

--- a/app/winkey.go
+++ b/app/winkey.go
@@ -15,14 +15,46 @@ import (
 // While the QEMU window is foreground: swallow Win on the host and forward it
 // to the guest as Super (meta_l) over a dedicated QMP socket. Otherwise the key
 // behaves normally. Pair with SDL_GRAB_KEYBOARD=0 so SDL never installs its own
-// (system-wide) hook.
+// (system-wide) hook. Print Screen gets the same treatment: Windows opens its
+// own screen capture on it system-wide, so Omarchy's screenshot binding would
+// otherwise fire together with Snipping Tool.
+
+type forwardedKey struct {
+	qcode string
+	down  bool
+}
 
 var (
 	qemuPid   atomic.Uint32 // current QEMU child, set by the supervisor
 	guestUp   atomic.Bool   // supervisor handshake succeeded for this launch
 	winDown   bool          // hook-thread only
-	keyEvents = make(chan bool, 64)
+	printDown bool          // hook-thread only
+	keyEvents = make(chan forwardedKey, 64)
 )
+
+// forwardKey hands a key state change to the QMP drain without blocking the
+// hook thread. Returns 1 so the host never sees the key.
+func forwardKey(state *bool, qcode string, down bool) uintptr {
+	if down != *state {
+		*state = down
+		select {
+		case keyEvents <- forwardedKey{qcode: qcode, down: down}:
+		default:
+		}
+	}
+	return 1
+}
+
+// releaseKey lets go of a forwarded key in the guest when focus leaves mid-press.
+func releaseKey(state *bool, qcode string) {
+	if *state {
+		*state = false
+		select {
+		case keyEvents <- forwardedKey{qcode: qcode, down: false}:
+		default:
+		}
+	}
+}
 
 func hookCallback(nCode, wParam, lParam uintptr) uintptr {
 	if int32(nCode) >= 0 {
@@ -37,27 +69,22 @@ func hookCallback(nCode, wParam, lParam uintptr) uintptr {
 			down := wParam == wmKeydown || wParam == wmSyskeydown
 			pid := qemuPid.Load()
 			if pid != 0 && foregroundPid() == pid {
-				if down != winDown {
-					winDown = down
-					select {
-					case keyEvents <- down:
-					default:
-					}
-				}
-				return 1 // swallow on host; QMP delivers it to the guest
+				return forwardKey(&winDown, "meta_l", down) // swallow on host; QMP delivers it to the guest
 			}
-			if winDown { // focus left mid-press: release in the guest
-				winDown = false
-				select {
-				case keyEvents <- false:
-				default:
-				}
-			}
+			releaseKey(&winDown, "meta_l") // focus left mid-press: release in the guest
 			// VM not focused: approve the key and SKIP the rest of the hook
 			// chain. QEMU installs its own LL hook on every grab which
 			// swallows Win even when unfocused; returning 0 without
 			// CallNextHookEx bypasses it.
 			return 0
+		}
+		if vk == vkSnapshot {
+			down := wParam == wmKeydown || wParam == wmSyskeydown
+			pid := qemuPid.Load()
+			if pid != 0 && foregroundPid() == pid {
+				return forwardKey(&printDown, "print", down)
+			}
+			releaseKey(&printDown, "print")
 		}
 	}
 	r, _, _ := procCallNextHookEx.Call(0, nCode, wParam, lParam)
@@ -124,8 +151,11 @@ func runWinKeyQmp() {
 	drain:
 		for {
 			select {
-			case down := <-keyEvents:
-				ev := fmt.Sprintf(`{"execute":"input-send-event","arguments":{"events":[{"type":"key","data":{"down":%t,"key":{"type":"qcode","data":"meta_l"}}}]}}`, down)
+			case key := <-keyEvents:
+				if key.qcode != "meta_l" && key.down {
+					logf("winkey: forwarded %s to the guest", key.qcode)
+				}
+				ev := fmt.Sprintf(`{"execute":"input-send-event","arguments":{"events":[{"type":"key","data":{"down":%t,"key":{"type":"qcode","data":%q}}}]}}`, key.down, key.qcode)
 				if err := c.writeLine(ev); err != nil {
 					break drain
 				}


### PR DESCRIPTION
Reported from the laptop run: pressing Print Screen inside Omarchy also opened Windows' Snipping Tool, so every screenshot had to be taken twice.

The focus-scoped low-level keyboard hook already swallows the Windows key while the VM window is in front and forwards it over QMP as Super. Print Screen now gets the same treatment: swallowed on the host while the VM window is foreground and delivered to the guest as the `print` key code, released in the guest if focus leaves mid-press, and passed through untouched everywhere else. The key forwarding channel carries the key code with each event now instead of assuming Super.

Verified in the Win11 VM: with the VM window in the foreground a Print Screen press left Snipping Tool closed, and an evdev logger inside the guest recorded key code 99 (Print) for the forwarded key, with F5 as a control. Omarchy's Print binding runs its screenshot helper, which the laptop run showed working on real hardware.