### PR TITLE
Keep the guest out of S3 and S4 sleep states

### DIFF
--- a/app/qemu.go
+++ b/app/qemu.go
@@ -66,6 +66,11 @@ func buildQemuArgs(cfg *config, cmdline string) []string {
 		"-device", "virtio-keyboard-pci", "-device", "virtio-tablet-pci",
 		"-device", "virtio-net-pci,netdev=n0", "-netdev", netdevArg(cfg.forwards),
 		"-device", "virtio-rng-pci",
+		// The guest must not sleep: a suspended VM leaves the window frozen
+		// with no way back from the keyboard, and Omarchy's power menu
+		// offers suspend whenever the kernel advertises it. With S3 and S4
+		// off the kernel reports no such state and systemd refuses cleanly.
+		"-global", "ICH9-LPC.disable_s3=1", "-global", "ICH9-LPC.disable_s4=1",
 		// The backend must be explicit: with no audiodev the guest's PipeWire
 		// stalls on virtio-snd control messages and the whole session hangs.
 		// cfg.audio is dsound normally; "none" on machines where DirectSound

--- a/app/qemu_nonwindows_test.go
+++ b/app/qemu_nonwindows_test.go
@@ -353,3 +353,13 @@ func TestBuildQemuArgsTellsTheGuestTheRenderingPath(t *testing.T) {
 		t.Fatalf("cpu marker missing: %s", args)
 	}
 }
+
+func TestBuildQemuArgsDisablesGuestSleepStates(t *testing.T) {
+	for _, gpu := range []bool{true, false} {
+		cfg := &config{vmDir: "/vm", guestDir: "/guest", disk: "/vm/disk.raw", diskFormat: "raw", memMiB: 4096, audio: "none", useGpu: gpu}
+		args := strings.Join(buildQemuArgs(cfg, "root=/dev/vda"), " ")
+		if !strings.Contains(args, "-global ICH9-LPC.disable_s3=1 -global ICH9-LPC.disable_s4=1") {
+			t.Fatalf("gpu=%v: sleep states not disabled: %s", gpu, args)
+		}
+	}
+}


### PR DESCRIPTION
Found during the post-release sweep. Choosing Suspend in Omarchy's power menu (or `systemctl suspend`) put the VM into QEMU's `suspended` state: the window froze, QMP still answered so the launcher's watchdog saw nothing wrong, and no keyboard input brought the guest back. Only a `system_wakeup` over QMP did.

With `-global ICH9-LPC.disable_s3=1` and `disable_s4=1` the guest cannot enter those states. A suspend request now falls through to suspend-to-idle, which keeps QEMU running and wakes on input; Omarchy's sleep lock still engages, so the user sees the lock screen rather than a dead window. Verified in the Win11 VM: `systemctl suspend` left QEMU reporting `running`, where the same command before this change reported `suspended`.

Seeding Omarchy's `suspend-off` toggle for new VM users, so the menu does not offer Suspend at all, follows as a guest patch.