### PR TITLE
Prepare v0.0.14-preview release notes

### DIFF
--- a/.github/release-notes/v0.0.14-preview.md
+++ b/.github/release-notes/v0.0.14-preview.md
@@ -1,0 +1,14 @@
+v0.0.14-preview follows v0.0.13-preview from earlier today. It ships a rebuilt guest image (integration revision 12) and a launcher fix worth not waiting for.
+
+### Fixed
+
+- Choosing Suspend inside Omarchy no longer freezes the VM window. The guest can no longer enter the S3 or S4 sleep states, and new guests have Omarchy's suspend-off toggle on so the system menu does not offer it.
+- A runtime archive that is unchanged between releases is kept instead of being downloaded and unpacked again.
+
+### New
+
+- The guest follows the Windows display language, alongside the time zone and keyboard layout it already follows. The locale is generated inside Omarchy and takes effect at the next login. `-locale` overrides it.
+- Existing guests catch up with the image defaults on the first boot after an image update, without touching anything you changed: an untouched `monitors.lua` gets the current profile, the toggles an older image switched on by mistake are removed, and Suspend leaves the system menu.
+- New guest images include the Noto CJK fonts.
+
+File drag and drop and file clipboard transfers are not included yet. Use `Omarchy Shared` for files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.0.14-preview - 2026-09-05
 
 ### Features
 - The guest follows the Windows display language: the launcher passes it along with the time zone and keyboard layout, and the guest generates that locale and makes it the default for the next login. `-locale` overrides it. Existing guests gain this with the next guest-image update.


### PR DESCRIPTION
Turns the Unreleased changelog section into v0.0.14-preview dated today and adds the release-notes file for the GitHub release body.